### PR TITLE
fix bitbucket token save issue in global config

### DIFF
--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/global/ScannerGlobalConfig.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/global/ScannerGlobalConfig.java
@@ -65,6 +65,7 @@ public class ScannerGlobalConfig extends GlobalConfiguration implements Serializ
     @DataBoundSetter
     public void setBitbucketCredentialsId(String bitbucketCredentialsId) {
         this.bitbucketCredentialsId = bitbucketCredentialsId;
+        save();
     }
 
     @DataBoundSetter
@@ -217,7 +218,7 @@ public class ScannerGlobalConfig extends GlobalConfiguration implements Serializ
                         ScanCredentialsHelper.USERNAME_PASSWORD_CREDENTIALS);
     }
 
-    public ListBoxModel doFillBitbucketTokenItems() {
+    public ListBoxModel doFillBitbucketCredentialsIdItems() {
         return getOptionsWithApiTokenCredentials();
     }
 }

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/global/ScannerGlobalConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/global/ScannerGlobalConfig/config.jelly
@@ -55,7 +55,7 @@
         </div>
 
         <div>
-            <f:entry field="bitbucketToken" title="Bitbucket Token (Optional)">
+            <f:entry field="bitbucketCredentialsId" title="Bitbucket Token (Optional)">
                <c:select/>
             </f:entry>
 


### PR DESCRIPTION
Previously Bitbucket token was not getting saved in global config.
There were some field renaming issues in code while migrating to jenkins credentials store.
Now it is fixed and tested.