### PR TITLE
Fix SIGINT-1267: blackduck_scan_full parameter behavior

### DIFF
--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep.java
@@ -34,10 +34,10 @@ public class SecurityScanStep extends Step implements Serializable {
     private String blackduck_url;
     private transient String blackduck_token;
     private String blackduck_install_directory;
-    private Boolean blackduck_scan_full = false;
+    private Boolean blackduck_scan_full;
     private String blackduck_scan_failure_severities;
     //    private Boolean blackduck_automation_fixpr;
-    private Boolean blackduck_automation_prcomment = false;
+    private Boolean blackduck_automation_prcomment;
     private String blackduck_download_url;
 
     private String coverity_url;

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep.java
@@ -219,7 +219,7 @@ public class SecurityScanStep extends Step implements Serializable {
 
     @DataBoundSetter
     public void setBlackduck_scan_full(Boolean blackduck_scan_full) {
-        this.blackduck_scan_full = blackduck_scan_full ? true : false;
+        this.blackduck_scan_full = blackduck_scan_full;
     }
 
     @DataBoundSetter
@@ -229,7 +229,7 @@ public class SecurityScanStep extends Step implements Serializable {
 
     @DataBoundSetter
     public void setBlackduck_automation_prcomment(Boolean blackduck_automation_prcomment) {
-        this.blackduck_automation_prcomment = blackduck_automation_prcomment ? true : false;
+        this.blackduck_automation_prcomment = blackduck_automation_prcomment;
     }
 
     @DataBoundSetter
@@ -274,7 +274,7 @@ public class SecurityScanStep extends Step implements Serializable {
 
     @DataBoundSetter
     public void setCoverity_automation_prcomment(Boolean coverity_automation_prcomment) {
-        this.coverity_automation_prcomment = coverity_automation_prcomment ? true : null;
+        this.coverity_automation_prcomment = coverity_automation_prcomment;
     }
 
     @DataBoundSetter
@@ -284,7 +284,7 @@ public class SecurityScanStep extends Step implements Serializable {
 
     @DataBoundSetter
     public void setCoverity_local(Boolean coverity_local) {
-        this.coverity_local = coverity_local ? true : null;
+        this.coverity_local = coverity_local;
     }
 
     @DataBoundSetter
@@ -344,12 +344,12 @@ public class SecurityScanStep extends Step implements Serializable {
 
     @DataBoundSetter
     public void setInclude_diagnostics(Boolean include_diagnostics) {
-        this.include_diagnostics = include_diagnostics ? true : null;
+        this.include_diagnostics = include_diagnostics;
     }
 
     @DataBoundSetter
     public void setNetwork_airgap(Boolean network_airgap) {
-        this.network_airgap = network_airgap ? true : null;
+        this.network_airgap = network_airgap;
     }
 
     private Map<String, Object> getParametersMap(FilePath workspace, TaskListener listener)

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep.java
@@ -34,10 +34,10 @@ public class SecurityScanStep extends Step implements Serializable {
     private String blackduck_url;
     private transient String blackduck_token;
     private String blackduck_install_directory;
-    private Boolean blackduck_scan_full;
+    private Boolean blackduck_scan_full = false;
     private String blackduck_scan_failure_severities;
     //    private Boolean blackduck_automation_fixpr;
-    private Boolean blackduck_automation_prcomment;
+    private Boolean blackduck_automation_prcomment = false;
     private String blackduck_download_url;
 
     private String coverity_url;
@@ -219,7 +219,7 @@ public class SecurityScanStep extends Step implements Serializable {
 
     @DataBoundSetter
     public void setBlackduck_scan_full(Boolean blackduck_scan_full) {
-        this.blackduck_scan_full = blackduck_scan_full ? true : null;
+        this.blackduck_scan_full = blackduck_scan_full ? true : false;
     }
 
     @DataBoundSetter
@@ -229,7 +229,7 @@ public class SecurityScanStep extends Step implements Serializable {
 
     @DataBoundSetter
     public void setBlackduck_automation_prcomment(Boolean blackduck_automation_prcomment) {
-        this.blackduck_automation_prcomment = blackduck_automation_prcomment ? true : null;
+        this.blackduck_automation_prcomment = blackduck_automation_prcomment ? true : false;
     }
 
     @DataBoundSetter

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactoryTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactoryTest.java
@@ -45,7 +45,7 @@ public class ScanParametersFactoryTest {
         Map<String, Object> result =
                 ScanParametersFactory.preparePipelineParametersMap(securityScanStep, globalConfigValues, listenerMock);
 
-        assertEquals(7, result.size());
+        assertEquals(5, result.size());
         assertEquals("BLACKDUCK", result.get(ApplicationConstants.PRODUCT_KEY));
         assertEquals("fake-blackduck-token", result.get(ApplicationConstants.BLACKDUCK_TOKEN_KEY));
         assertEquals("/fake/path", result.get(ApplicationConstants.SYNOPSYS_BRIDGE_INSTALL_DIRECTORY));
@@ -86,7 +86,7 @@ public class ScanParametersFactoryTest {
         Map<String, Object> emptyBlackDuckParametersMap =
                 ScanParametersFactory.prepareBlackDuckParametersMap(new SecurityScanStep());
 
-        assertEquals(2, emptyBlackDuckParametersMap.size());
+        assertEquals(0, emptyBlackDuckParametersMap.size());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactoryTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactoryTest.java
@@ -45,7 +45,7 @@ public class ScanParametersFactoryTest {
         Map<String, Object> result =
                 ScanParametersFactory.preparePipelineParametersMap(securityScanStep, globalConfigValues, listenerMock);
 
-        assertEquals(5, result.size());
+        assertEquals(7, result.size());
         assertEquals("BLACKDUCK", result.get(ApplicationConstants.PRODUCT_KEY));
         assertEquals("fake-blackduck-token", result.get(ApplicationConstants.BLACKDUCK_TOKEN_KEY));
         assertEquals("/fake/path", result.get(ApplicationConstants.SYNOPSYS_BRIDGE_INSTALL_DIRECTORY));
@@ -86,7 +86,7 @@ public class ScanParametersFactoryTest {
         Map<String, Object> emptyBlackDuckParametersMap =
                 ScanParametersFactory.prepareBlackDuckParametersMap(new SecurityScanStep());
 
-        assertEquals(0, emptyBlackDuckParametersMap.size());
+        assertEquals(2, emptyBlackDuckParametersMap.size());
     }
 
     @Test


### PR DESCRIPTION
This PR will fix the problem described in SIGINT-1267 where even if blackduck_scan_full was not specified or set to false, it still ran an intelligent scan. Made changes to set to blackduck_scan_full to false along with automation_prcomment to avoid any future issues. 

Testing was done for all the scenarios where we set blackduck_scan_full to either true, false or do not pass it in the Jenkinsfile for the bitbucket project. 
