### PR TITLE
SIGINT-1417: Download bridge ARM specific binary for Coverity ARM support

### DIFF
--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ApplicationConstants.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ApplicationConstants.java
@@ -14,6 +14,7 @@ public class ApplicationConstants {
     public static final String PLATFORM_WINDOWS = "win64";
     public static final String PLATFORM_MAC_ARM = "macos_arm";
     public static final String PLATFORM_MACOSX = "macosx";
+    public static final String MAC_ARM_COMPATIBLE_BRIDGE_VERSION = "2.1.0";
     public static final String DEFAULT_DIRECTORY_NAME = "synopsys-bridge";
     public static final String BRIDGE_DIAGNOSTICS_DIRECTORY = ".bridge";
     public static final int BRIDGE_DOWNLOAD_MAX_RETRIES = 3;

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ApplicationConstants.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ApplicationConstants.java
@@ -12,7 +12,8 @@ public class ApplicationConstants {
     public static final String BRIDGE_ZIP_FILE_FORMAT = "bridge.zip";
     public static final String PLATFORM_LINUX = "linux64";
     public static final String PLATFORM_WINDOWS = "win64";
-    public static final String PLATFORM_MAC = "macosx";
+    public static final String PLATFORM_MAC_ARM = "macos_arm";
+    public static final String PLATFORM_MACOSX = "macosx";
     public static final String DEFAULT_DIRECTORY_NAME = "synopsys-bridge";
     public static final String BRIDGE_DIAGNOSTICS_DIRECTORY = ".bridge";
     public static final int BRIDGE_DOWNLOAD_MAX_RETRIES = 3;

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/OsArchTask.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/OsArchTask.java
@@ -1,0 +1,13 @@
+package io.jenkins.plugins.synopsys.security.scan.global;
+
+import hudson.FilePath;
+import hudson.remoting.VirtualChannel;
+import java.io.File;
+import jenkins.MasterToSlaveFileCallable;
+
+public class OsArchTask extends MasterToSlaveFileCallable<String> implements FilePath.FileCallable<String> {
+    @Override
+    public String invoke(File workspace, VirtualChannel channel) {
+        return System.getProperty("os.arch").toLowerCase();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/Utility.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/Utility.java
@@ -43,6 +43,25 @@ public class Utility {
         return os;
     }
 
+    public static String getAgentOsArch(FilePath workspace, TaskListener listener) {
+        String arch = null;
+        LoggerWrapper logger = new LoggerWrapper(listener);
+
+        if (workspace.isRemote()) {
+            try {
+                arch = workspace.act(new OsArchTask());
+            } catch (IOException | InterruptedException e) {
+                logger.error("An exception occurred while fetching the OS information for the agent node: "
+                        + e.getMessage());
+                Thread.currentThread().interrupt();
+            }
+        } else {
+            arch = System.getProperty("os.arch").toLowerCase();
+        }
+
+        return arch;
+    }
+
     public static void removeFile(String filePath, FilePath workspace, TaskListener listener) {
         LoggerWrapper logger = new LoggerWrapper(listener);
         try {

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/Utility.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/Utility.java
@@ -51,7 +51,7 @@ public class Utility {
             try {
                 arch = workspace.act(new OsArchTask());
             } catch (IOException | InterruptedException e) {
-                logger.error("An exception occurred while fetching the OS information for the agent node: "
+                logger.error("An exception occurred while fetching OS architecture information for the agent node: "
                         + e.getMessage());
                 Thread.currentThread().interrupt();
             }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/Utility.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/Utility.java
@@ -177,23 +177,4 @@ public class Utility {
 
         return proxyUrlString;
     }
-
-    public static int compareVersions(String version1, String version2) {
-        int comparisonResult = 0;
-
-        String[] version1Splits = version1.split("\\.");
-        String[] version2Splits = version2.split("\\.");
-        int maxLengthOfVersionSplits = Math.max(version1Splits.length, version2Splits.length);
-
-        for (int i = 0; i < maxLengthOfVersionSplits; i++) {
-            Integer v1 = i < version1Splits.length ? Integer.parseInt(version1Splits[i]) : 0;
-            Integer v2 = i < version2Splits.length ? Integer.parseInt(version2Splits[i]) : 0;
-            int compare = v1.compareTo(v2);
-            if (compare != 0) {
-                comparisonResult = compare;
-                break;
-            }
-        }
-        return comparisonResult;
-    }
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/Utility.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/Utility.java
@@ -177,4 +177,23 @@ public class Utility {
 
         return proxyUrlString;
     }
+
+    public static int compareVersions(String version1, String version2) {
+        int comparisonResult = 0;
+
+        String[] version1Splits = version1.split("\\.");
+        String[] version2Splits = version2.split("\\.");
+        int maxLengthOfVersionSplits = Math.max(version1Splits.length, version2Splits.length);
+
+        for (int i = 0; i < maxLengthOfVersionSplits; i++) {
+            Integer v1 = i < version1Splits.length ? Integer.parseInt(version1Splits[i]) : 0;
+            Integer v2 = i < version2Splits.length ? Integer.parseInt(version2Splits[i]) : 0;
+            int compare = v1.compareTo(v2);
+            if (compare != 0) {
+                comparisonResult = compare;
+                break;
+            }
+        }
+        return comparisonResult;
+    }
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParametersService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParametersService.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.synopsys.security.scan.service.bridge;
 
+import com.fasterxml.jackson.core.Version;
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.bridge.BridgeDownloadParameters;
@@ -144,8 +145,7 @@ public class BridgeDownloadParametersService {
             return ApplicationConstants.PLATFORM_WINDOWS;
         } else if (os.contains("mac")) {
             String arch = Utility.getAgentOsArch(workspace, listener);
-            if (version != null
-                    && Utility.compareVersions(version, ApplicationConstants.MAC_ARM_COMPATIBLE_BRIDGE_VERSION) < 0) {
+            if (version != null && !isVersionCompatibleForMacARM(version)) {
                 return ApplicationConstants.PLATFORM_MACOSX;
             } else {
                 if (arch.startsWith("arm") || arch.startsWith("aarch")) {
@@ -173,5 +173,29 @@ public class BridgeDownloadParametersService {
                 .concat("-")
                 .concat(getPlatform(version))
                 .concat(".zip");
+    }
+
+    public boolean isVersionCompatibleForMacARM(String version) {
+        String[] inputVersionSplits = version.split("\\.");
+        String[] minCompatibleArmVersionSplits = ApplicationConstants.MAC_ARM_COMPATIBLE_BRIDGE_VERSION.split("\\.");
+        if (inputVersionSplits.length != 3 && minCompatibleArmVersionSplits.length != 3) {
+            return false;
+        }
+        Version inputVersion = new Version(
+                Integer.parseInt(inputVersionSplits[0]),
+                Integer.parseInt(inputVersionSplits[1]),
+                Integer.parseInt(inputVersionSplits[2]),
+                null,
+                null,
+                null);
+        Version minCompatibleArmVersion = new Version(
+                Integer.parseInt(minCompatibleArmVersionSplits[0]),
+                Integer.parseInt(minCompatibleArmVersionSplits[1]),
+                Integer.parseInt(minCompatibleArmVersionSplits[2]),
+                null,
+                null,
+                null);
+
+        return inputVersion.compareTo(minCompatibleArmVersion) >= 0;
     }
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParametersService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParametersService.java
@@ -138,16 +138,21 @@ public class BridgeDownloadParametersService {
         return bridgeDownloadParameters;
     }
 
-    public String getPlatform() {
+    public String getPlatform(String version) {
         String os = Utility.getAgentOs(workspace, listener);
         if (os.contains("win")) {
             return ApplicationConstants.PLATFORM_WINDOWS;
         } else if (os.contains("mac")) {
             String arch = Utility.getAgentOsArch(workspace, listener);
-            if (arch.startsWith("arm") || arch.startsWith("aarch")) {
-                return ApplicationConstants.PLATFORM_MAC_ARM;
-            } else {
+            if (version != null
+                    && Utility.compareVersions(version, ApplicationConstants.MAC_ARM_COMPATIBLE_BRIDGE_VERSION) < 0) {
                 return ApplicationConstants.PLATFORM_MACOSX;
+            } else {
+                if (arch.startsWith("arm") || arch.startsWith("aarch")) {
+                    return ApplicationConstants.PLATFORM_MAC_ARM;
+                } else {
+                    return ApplicationConstants.PLATFORM_MACOSX;
+                }
             }
         } else {
             return ApplicationConstants.PLATFORM_LINUX;
@@ -157,7 +162,7 @@ public class BridgeDownloadParametersService {
     public String getSynopsysBridgeZipFileName() {
         return ApplicationConstants.BRIDGE_BINARY
                 .concat("-")
-                .concat(getPlatform())
+                .concat(getPlatform(null))
                 .concat(".zip");
     }
 
@@ -166,7 +171,7 @@ public class BridgeDownloadParametersService {
                 .concat("-")
                 .concat(version)
                 .concat("-")
-                .concat(getPlatform())
+                .concat(getPlatform(version))
                 .concat(".zip");
     }
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParametersService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParametersService.java
@@ -143,7 +143,12 @@ public class BridgeDownloadParametersService {
         if (os.contains("win")) {
             return ApplicationConstants.PLATFORM_WINDOWS;
         } else if (os.contains("mac")) {
-            return ApplicationConstants.PLATFORM_MAC;
+            String arch = Utility.getAgentOsArch(workspace, listener);
+            if (arch.startsWith("arm") || arch.startsWith("aarch")) {
+                return ApplicationConstants.PLATFORM_MAC_ARM;
+            } else {
+                return ApplicationConstants.PLATFORM_MACOSX;
+            }
         } else {
             return ApplicationConstants.PLATFORM_LINUX;
         }

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/global/UtilityTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/global/UtilityTest.java
@@ -172,6 +172,15 @@ public class UtilityTest {
         assertNull(Authenticator.getDefault());
     }
 
+    @Test
+    public void compareVersionsTest() {
+        assertTrue(Utility.compareVersions("1.0.1", "1.1.2") < 0);
+        assertTrue(Utility.compareVersions("1.0.1", "1.10") < 0);
+        assertTrue(Utility.compareVersions("1.1.2", "1.0.1") > 0);
+        assertTrue(Utility.compareVersions("1.1.2", "1.2.0") < 0);
+        assertEquals(0, Utility.compareVersions("1.3.0", "1.3"));
+    }
+
     public String getHomeDirectory() {
         return System.getProperty("user.home");
     }

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/global/UtilityTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/global/UtilityTest.java
@@ -172,15 +172,6 @@ public class UtilityTest {
         assertNull(Authenticator.getDefault());
     }
 
-    @Test
-    public void compareVersionsTest() {
-        assertTrue(Utility.compareVersions("1.0.1", "1.1.2") < 0);
-        assertTrue(Utility.compareVersions("1.0.1", "1.10") < 0);
-        assertTrue(Utility.compareVersions("1.1.2", "1.0.1") > 0);
-        assertTrue(Utility.compareVersions("1.1.2", "1.2.0") < 0);
-        assertEquals(0, Utility.compareVersions("1.3.0", "1.3"));
-    }
-
     public String getHomeDirectory() {
         return System.getProperty("user.home");
     }

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/global/UtilityTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/global/UtilityTest.java
@@ -1,23 +1,18 @@
 package io.jenkins.plugins.synopsys.security.scan.global;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
-
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.net.Authenticator;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.PasswordAuthentication;
-import java.net.URL;
+import java.net.*;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 
 public class UtilityTest {
     private FilePath workspace;
@@ -56,6 +51,13 @@ public class UtilityTest {
         String os = Utility.getAgentOs(workspace, listenerMock);
 
         assertEquals(System.getProperty("os.name").toLowerCase(), os);
+    }
+
+    @Test
+    public void getAgentOsArchTest() {
+        String arch = Utility.getAgentOsArch(workspace, listenerMock);
+
+        assertEquals(System.getProperty("os.arch").toLowerCase(), arch);
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/global/UtilityTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/global/UtilityTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.synopsys.security.scan.global;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.TaskListener;
@@ -11,8 +14,6 @@ import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
 
 public class UtilityTest {
     private FilePath workspace;

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParameterServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParameterServiceTest.java
@@ -1,6 +1,9 @@
 package io.jenkins.plugins.synopsys.security.scan.service.bridge;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.FilePath;
 import hudson.model.TaskListener;
@@ -147,6 +150,28 @@ public class BridgeDownloadParameterServiceTest {
         assertNotNull(result.getBridgeDownloadUrl());
         assertNotNull(result.getBridgeDownloadVersion());
         assertNotNull(result.getBridgeInstallationPath());
+    }
+
+    @Test
+    void getPlatformTest() {
+        String osName = System.getProperty("os.name");
+        String osArch = System.getProperty("os.arch");
+
+        String platform = bridgeDownloadParametersService.getPlatform();
+
+        assertNotNull(platform);
+
+        if (osName.contains("win")) {
+            assertEquals(ApplicationConstants.PLATFORM_WINDOWS, platform);
+        } else if (osName.contains("mac")) {
+            if (osArch.startsWith("arm") || osArch.startsWith("aarch")) {
+                assertEquals(ApplicationConstants.PLATFORM_MAC_ARM, platform);
+            } else {
+                assertEquals(ApplicationConstants.PLATFORM_MACOSX, platform);
+            }
+        } else {
+            assertEquals(ApplicationConstants.PLATFORM_LINUX, platform);
+        }
     }
 
     public String getHomeDirectory() {

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParameterServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParameterServiceTest.java
@@ -157,7 +157,7 @@ public class BridgeDownloadParameterServiceTest {
         String osName = System.getProperty("os.name").toLowerCase();
         String osArch = System.getProperty("os.arch").toLowerCase();
 
-        String platform = bridgeDownloadParametersService.getPlatform();
+        String platform = bridgeDownloadParametersService.getPlatform(null);
 
         assertNotNull(platform);
 

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParameterServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParameterServiceTest.java
@@ -174,6 +174,14 @@ public class BridgeDownloadParameterServiceTest {
         }
     }
 
+    @Test
+    public void isVersionCompatibleForMacARMTest() {
+        assertTrue(bridgeDownloadParametersService.isVersionCompatibleForMacARM("2.1.0"));
+        assertTrue(bridgeDownloadParametersService.isVersionCompatibleForMacARM("2.2.38"));
+        assertFalse(bridgeDownloadParametersService.isVersionCompatibleForMacARM("2.0.0"));
+        assertFalse(bridgeDownloadParametersService.isVersionCompatibleForMacARM("1.2.12"));
+    }
+
     public String getHomeDirectory() {
         return System.getProperty("user.home");
     }

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParameterServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParameterServiceTest.java
@@ -154,8 +154,8 @@ public class BridgeDownloadParameterServiceTest {
 
     @Test
     void getPlatformTest() {
-        String osName = System.getProperty("os.name");
-        String osArch = System.getProperty("os.arch");
+        String osName = System.getProperty("os.name").toLowerCase();
+        String osArch = System.getProperty("os.arch").toLowerCase();
 
         String platform = bridgeDownloadParametersService.getPlatform();
 


### PR DESCRIPTION
- Made code changes for downloading bridge ARM specific binary in `getPlatform` method of `BridgeDownloadParametersService` classs
- Added support for multi agent configuration with `OsArchTask` class
- Added unit test
- Added support backward compatibility for older bridge version for ARM support (**SIGINT-1473**)