### PR TITLE
SIGINT-1422: Jenkins Plugin: support normal scanning through Pipeline

### DIFF
--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/SCMRepositoryService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/SCMRepositoryService.java
@@ -56,8 +56,7 @@ public class SCMRepositoryService {
     }
 
     public SCMSource findSCMSource() {
-        String jobName = envVars.get(ApplicationConstants.ENV_JOB_NAME_KEY)
-                .substring(0, envVars.get(ApplicationConstants.ENV_JOB_NAME_KEY).indexOf("/"));
+        String jobName = envVars.get(ApplicationConstants.ENV_JOB_NAME_KEY);
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         SCMSourceOwner owner = jenkins != null ? jenkins.getItemByFullName(jobName, SCMSourceOwner.class) : null;
         if (owner != null) {


### PR DESCRIPTION
- Refactored the **findSCMSource** method **SCMRepositoryService** class to extract the full job name of the build.
- Tested successfully for blackduck.
- Tested successfully for polaris.
- Also tested for both bitbucket and github scm successfully.
- Tested it with the both scripted and declarative pipeline syntax.
- Tested it successfully on Agent node.