### PR TITLE
SIGINT-1490: Excluded vulnerable library from gitlab branch source plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>gitlab-branch-source</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.jettison</groupId>
+          <artifactId>jettison</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
- Fixed POP vulnerabilities by excluding the library from `gitlab-branch-source` plugin