### PR TITLE
SIGINT-1485: support return_status to enable post scan actions in pipeline

### DIFF
--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandler.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandler.java
@@ -152,7 +152,9 @@ public class PluginParametersHandler {
             if (key.equals(ApplicationConstants.SYNOPSYS_BRIDGE_DOWNLOAD_URL)
                     || key.equals(ApplicationConstants.SYNOPSYS_BRIDGE_DOWNLOAD_VERSION)
                     || key.equals(ApplicationConstants.SYNOPSYS_BRIDGE_INSTALL_DIRECTORY)
-                    || key.equals(ApplicationConstants.INCLUDE_DIAGNOSTICS_KEY)) {
+                    || key.equals(ApplicationConstants.INCLUDE_DIAGNOSTICS_KEY)
+                    || key.equals(ApplicationConstants.NETWORK_AIRGAP_KEY)
+                    || key.equals(ApplicationConstants.RETURN_STATUS_KEY)) {
                 Object value = entry.getValue();
                 logger.info(LOG_DASH + key + " = " + value.toString());
             }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandler.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandler.java
@@ -41,7 +41,7 @@ public class PluginParametersHandler {
 
         logMessagesForParameters(scanParameters, scanParametersService.getSynopsysSecurityProducts(scanParameters));
 
-        int exitCode = 31; // Scan parameter validation failure error code
+        int exitCode = ErrorCode.PARAMETER_VALIDATION_FAILED;
 
         if (isValidScanParametersAndBridgeDownload(
                 bridgeDownloadParams, scanParametersService, bridgeDownloadParametersService, scanParameters)) {

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandler.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandler.java
@@ -88,7 +88,7 @@ public class PluginParametersHandler {
             throws PluginExceptionHandler {
         if (isNetworkAirgap && !bridgeDownloadParams.getBridgeDownloadUrl().contains(".zip") && !isBridgeInstalled) {
             logger.error("Synopsys Bridge could not be found in " + bridgeDownloadParams.getBridgeInstallationPath());
-            throw new PluginExceptionHandler(ErrorCode.BRIDGE_EXECUTABLE_NOT_FOUND,
+            throw new PluginExceptionHandler(ErrorCode.SYNOPSYS_BRIDGE_EXECUTABLE_NOT_FOUND,
                     "Synopsys Bridge could not be found in " + bridgeDownloadParams.getBridgeInstallationPath());
         }
 

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandler.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandler.java
@@ -48,7 +48,7 @@ public class PluginParametersHandler {
         BridgeDownloadManager bridgeDownloadManager = new BridgeDownloadManager(workspace, listener, envVars);
         boolean isNetworkAirGap = checkNetworkAirgap(scanParameters);
         boolean isBridgeInstalled =
-            bridgeDownloadManager.checkIfBridgeInstalled(bridgeDownloadParams.getBridgeInstallationPath());
+                bridgeDownloadManager.checkIfBridgeInstalled(bridgeDownloadParams.getBridgeInstallationPath());
         boolean isBridgeDownloadRequired = true;
 
         handleNetworkAirgap(isNetworkAirGap, bridgeDownloadParams, isBridgeInstalled);
@@ -57,11 +57,10 @@ public class PluginParametersHandler {
             isBridgeDownloadRequired = bridgeDownloadManager.isSynopsysBridgeDownloadRequired(bridgeDownloadParams);
         }
 
-        handleBridgeDownload(
-            isBridgeDownloadRequired, isNetworkAirGap, bridgeDownloadParams, bridgeDownloadManager);
+        handleBridgeDownload(isBridgeDownloadRequired, isNetworkAirGap, bridgeDownloadParams, bridgeDownloadManager);
 
         FilePath bridgeInstallationPath =
-            new FilePath(workspace.getChannel(), bridgeDownloadParams.getBridgeInstallationPath());
+                new FilePath(workspace.getChannel(), bridgeDownloadParams.getBridgeInstallationPath());
 
         return scanner.runScanner(scanParameters, bridgeInstallationPath);
     }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandler.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandler.java
@@ -41,7 +41,7 @@ public class PluginParametersHandler {
 
         logMessagesForParameters(scanParameters, scanParametersService.getSynopsysSecurityProducts(scanParameters));
 
-        int exitCode = ErrorCode.PARAMETER_VALIDATION_FAILED;
+        int exitCode = ErrorCode.UNDEFINED_PLUGIN_ERROR;
 
         if (isValidScanParametersAndBridgeDownload(
                 bridgeDownloadParams, scanParametersService, bridgeDownloadParametersService, scanParameters)) {
@@ -73,7 +73,7 @@ public class PluginParametersHandler {
             BridgeDownloadParameters bridgeDownloadParams,
             ScanParametersService scanParametersService,
             BridgeDownloadParametersService bridgeDownloadParametersService,
-            Map<String, Object> scanParameters) {
+            Map<String, Object> scanParameters) throws PluginExceptionHandler {
         return scanParametersService.isValidScanParameters(scanParameters)
                 && bridgeDownloadParametersService.performBridgeDownloadParameterValidation(bridgeDownloadParams);
     }
@@ -88,9 +88,7 @@ public class PluginParametersHandler {
             throws PluginExceptionHandler {
         if (isNetworkAirgap && !bridgeDownloadParams.getBridgeDownloadUrl().contains(".zip") && !isBridgeInstalled) {
             logger.error("Synopsys Bridge could not be found in " + bridgeDownloadParams.getBridgeInstallationPath());
-            throw new PluginExceptionHandler(
-                    ErrorCode.SYNOPSYS_BRIDGE_EXECUTABLE_NOT_FOUND,
-                    "Synopsys Bridge could not be found in " + bridgeDownloadParams.getBridgeInstallationPath());
+            throw new PluginExceptionHandler(ErrorCode.SYNOPSYS_BRIDGE_NOT_FOUND_IN_PROVIDED_PATH);
         }
 
         if (isNetworkAirgap) {

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandler.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandler.java
@@ -88,7 +88,8 @@ public class PluginParametersHandler {
             throws PluginExceptionHandler {
         if (isNetworkAirgap && !bridgeDownloadParams.getBridgeDownloadUrl().contains(".zip") && !isBridgeInstalled) {
             logger.error("Synopsys Bridge could not be found in " + bridgeDownloadParams.getBridgeInstallationPath());
-            throw new PluginExceptionHandler(ErrorCode.SYNOPSYS_BRIDGE_EXECUTABLE_NOT_FOUND,
+            throw new PluginExceptionHandler(
+                    ErrorCode.SYNOPSYS_BRIDGE_EXECUTABLE_NOT_FOUND,
                     "Synopsys Bridge could not be found in " + bridgeDownloadParams.getBridgeInstallationPath());
         }
 

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/SecurityScanner.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/SecurityScanner.java
@@ -8,7 +8,6 @@ import hudson.model.TaskListener;
 import hudson.tasks.ArtifactArchiver;
 import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
-import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.global.Utility;
 import io.jenkins.plugins.synopsys.security.scan.service.ScannerArgumentService;
@@ -70,7 +69,7 @@ public class SecurityScanner {
                     .quiet(true)
                     .join();
         } catch (Exception e) {
-            logger.error(LogMessages.EXCEPTION_OCCURRED_WHILE_INVOKING_SYNOPSYS_BRIDGE, e.getMessage());
+            logger.error("An exception occurred while invoking synopsys-bridge from the plugin: %s", e.getMessage());
             Thread.currentThread().interrupt();
         } finally {
             logger.println(

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/SecurityScanner.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/SecurityScanner.java
@@ -44,7 +44,7 @@ public class SecurityScanner {
 
     public int runScanner(Map<String, Object> scanParams, FilePath bridgeInstallationPath)
             throws PluginExceptionHandler {
-        int scanner = -1;
+        int scanner = 0;
 
         List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(
                 Utility.installedBranchSourceDependcies(), scanParams, bridgeInstallationPath);

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownload.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownload.java
@@ -45,7 +45,7 @@ public class BridgeDownload {
                 }
             } catch (InterruptedException e) {
                 logger.error(LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_RETRY_INTERRUPTED);
-                throw new PluginExceptionHandler(ErrorCode.BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_RETRY_INTERRUPTED);
+                throw new PluginExceptionHandler(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_RETRY_INTERRUPTED);
             } catch (Exception e) {
                 handleDownloadException(e, bridgeDownloadUrl, retryCount);
                 retryCount++;
@@ -59,7 +59,7 @@ public class BridgeDownload {
         }
 
         if (bridgeZipFilePath == null) {
-            throw new PluginExceptionHandler(ErrorCode.BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED);
+            throw new PluginExceptionHandler(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED);
         }
 
         return bridgeZipFilePath;
@@ -84,7 +84,7 @@ public class BridgeDownload {
             logger.error(
                     LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY,
                     statusCode);
-            throw new PluginExceptionHandler(ErrorCode.BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY);
+            throw new PluginExceptionHandler(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY);
         }
 
         Thread.sleep(ApplicationConstants.INTERVAL_BETWEEN_CONSECUTIVE_RETRY_ATTEMPTS);

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownload.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownload.java
@@ -23,7 +23,8 @@ public class BridgeDownload {
         this.envVars = envVars;
     }
 
-    public FilePath downloadSynopsysBridge(String bridgeDownloadUrl, String bridgeInstallationPath) throws PluginExceptionHandler {
+    public FilePath downloadSynopsysBridge(String bridgeDownloadUrl, String bridgeInstallationPath)
+            throws PluginExceptionHandler {
         FilePath bridgeZipFilePath = null;
         FilePath bridgeInstallationFilePath = new FilePath(workspace.getChannel(), bridgeInstallationPath);
 
@@ -64,7 +65,8 @@ public class BridgeDownload {
         return bridgeZipFilePath;
     }
 
-    private FilePath downloadBridge(String bridgeDownloadUrl, FilePath bridgeInstallationFilePath) throws InterruptedException, IOException {
+    private FilePath downloadBridge(String bridgeDownloadUrl, FilePath bridgeInstallationFilePath)
+            throws InterruptedException, IOException {
         FilePath bridgeZipFilePath = bridgeInstallationFilePath.child(ApplicationConstants.BRIDGE_ZIP_FILE_FORMAT);
         HttpURLConnection connection = Utility.getHttpURLConnection(new URL(bridgeDownloadUrl), envVars, logger);
 
@@ -80,7 +82,9 @@ public class BridgeDownload {
         int statusCode = getHttpStatusCode(bridgeDownloadUrl);
 
         if (terminateRetry(statusCode)) {
-            logger.error("Synopsys Bridge download failed with status code: %s and plugin won't retry to download", statusCode);
+            logger.error(
+                    "Synopsys Bridge download failed with status code: %s and plugin won't retry to download",
+                    statusCode);
             throw new PluginExceptionHandler(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY);
         }
 

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownload.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownload.java
@@ -5,6 +5,7 @@ import hudson.FilePath;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
+import io.jenkins.plugins.synopsys.security.scan.global.ErrorCode;
 import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.global.Utility;
@@ -43,8 +44,8 @@ public class BridgeDownload {
                     downloadSuccess = true;
                 }
             } catch (InterruptedException e) {
-                logger.error("Interrupted while waiting to retry Synopsys Bridge download");
-                throw e;
+                logger.error(LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_RETRY_INTERRUPTED);
+                throw new PluginExceptionHandler(ErrorCode.BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_RETRY_INTERRUPTED);
             } catch (Exception e) {
                 handleDownloadException(e, bridgeDownloadUrl, retryCount);
                 retryCount++;
@@ -58,7 +59,7 @@ public class BridgeDownload {
         }
 
         if (bridgeZipFilePath == null) {
-            throw new PluginExceptionHandler(LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED);
+            throw new PluginExceptionHandler(ErrorCode.BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED);
         }
 
         return bridgeZipFilePath;
@@ -81,9 +82,9 @@ public class BridgeDownload {
 
         if (terminateRetry(statusCode)) {
             logger.error(
-                    "Synopsys Bridge download failed with status code: %s and plugin won't retry to download.",
+                    LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY,
                     statusCode);
-            throw e;
+            throw new PluginExceptionHandler(ErrorCode.BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY);
         }
 
         Thread.sleep(ApplicationConstants.INTERVAL_BETWEEN_CONSECUTIVE_RETRY_ATTEMPTS);

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownload.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownload.java
@@ -45,7 +45,9 @@ public class BridgeDownload {
                 }
             } catch (InterruptedException e) {
                 logger.error(LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_RETRY_INTERRUPTED);
-                throw new PluginExceptionHandler(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_RETRY_INTERRUPTED);
+                throw new PluginExceptionHandler(
+                        ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED,
+                        LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_RETRY_INTERRUPTED);
             } catch (Exception e) {
                 handleDownloadException(e, bridgeDownloadUrl, retryCount);
                 retryCount++;
@@ -59,7 +61,9 @@ public class BridgeDownload {
         }
 
         if (bridgeZipFilePath == null) {
-            throw new PluginExceptionHandler(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED);
+            throw new PluginExceptionHandler(
+                    ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED,
+                    LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED);
         }
 
         return bridgeZipFilePath;
@@ -81,10 +85,10 @@ public class BridgeDownload {
         int statusCode = getHttpStatusCode(bridgeDownloadUrl);
 
         if (terminateRetry(statusCode)) {
-            logger.error(
-                    LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY,
-                    statusCode);
-            throw new PluginExceptionHandler(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY);
+            logger.error(LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY, statusCode);
+            throw new PluginExceptionHandler(
+                    ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED,
+                    LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY);
         }
 
         Thread.sleep(ApplicationConstants.INTERVAL_BETWEEN_CONSECUTIVE_RETRY_ATTEMPTS);

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownloadManager.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownloadManager.java
@@ -44,7 +44,7 @@ public class BridgeDownloadManager {
         } catch (Exception e) {
             logger.error(
                     LogMessages.EXCEPTION_OCCURRED_WHILE_DOWNLOADING_OR_INSTALLING_SYNOPSYS_BRIDGE, e.getMessage());
-            throw new PluginExceptionHandler(ErrorCode.BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, e.getMessage());
+            throw new PluginExceptionHandler(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, e.getMessage());
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownloadManager.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownloadManager.java
@@ -5,6 +5,7 @@ import hudson.FilePath;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
+import io.jenkins.plugins.synopsys.security.scan.global.ErrorCode;
 import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.global.Utility;
@@ -43,7 +44,7 @@ public class BridgeDownloadManager {
         } catch (Exception e) {
             logger.error(
                     LogMessages.EXCEPTION_OCCURRED_WHILE_DOWNLOADING_OR_INSTALLING_SYNOPSYS_BRIDGE, e.getMessage());
-            throw new PluginExceptionHandler(e.getMessage());
+            throw new PluginExceptionHandler(ErrorCode.BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, e.getMessage());
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownloadManager.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownloadManager.java
@@ -40,7 +40,8 @@ public class BridgeDownloadManager {
 
         FilePath bridgeZipPath = bridgeDownload.downloadSynopsysBridge(bridgeDownloadUrl, bridgeInstallationPath);
 
-        bridgeInstall.installSynopsysBridge(bridgeZipPath, new FilePath(workspace.getChannel(), bridgeInstallationPath));
+        bridgeInstall.installSynopsysBridge(
+                bridgeZipPath, new FilePath(workspace.getChannel(), bridgeInstallationPath));
     }
 
     public boolean isSynopsysBridgeDownloadRequired(BridgeDownloadParameters bridgeDownloadParameters) {

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownloadManager.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeDownloadManager.java
@@ -5,12 +5,13 @@ import hudson.FilePath;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
-import io.jenkins.plugins.synopsys.security.scan.global.ErrorCode;
-import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.global.Utility;
 import java.io.IOException;
-import java.net.*;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -37,15 +38,9 @@ public class BridgeDownloadManager {
 
         bridgeInstall.verifyAndCreateInstallationPath(bridgeInstallationPath);
 
-        try {
-            FilePath bridgeZipPath = bridgeDownload.downloadSynopsysBridge(bridgeDownloadUrl, bridgeInstallationPath);
-            bridgeInstall.installSynopsysBridge(
-                    bridgeZipPath, new FilePath(workspace.getChannel(), bridgeInstallationPath));
-        } catch (Exception e) {
-            logger.error(
-                    LogMessages.EXCEPTION_OCCURRED_WHILE_DOWNLOADING_OR_INSTALLING_SYNOPSYS_BRIDGE, e.getMessage());
-            throw new PluginExceptionHandler(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, e.getMessage());
-        }
+        FilePath bridgeZipPath = bridgeDownload.downloadSynopsysBridge(bridgeDownloadUrl, bridgeInstallationPath);
+
+        bridgeInstall.installSynopsysBridge(bridgeZipPath, new FilePath(workspace.getChannel(), bridgeInstallationPath));
     }
 
     public boolean isSynopsysBridgeDownloadRequired(BridgeDownloadParameters bridgeDownloadParameters) {

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeInstall.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeInstall.java
@@ -2,8 +2,9 @@ package io.jenkins.plugins.synopsys.security.scan.bridge;
 
 import hudson.FilePath;
 import hudson.model.TaskListener;
+import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
+import io.jenkins.plugins.synopsys.security.scan.global.ErrorCode;
 import io.jenkins.plugins.synopsys.security.scan.global.HomeDirectoryTask;
-import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.global.Utility;
 import java.io.IOException;
@@ -18,18 +19,25 @@ public class BridgeInstall {
         this.logger = new LoggerWrapper(listener);
     }
 
-    public void installSynopsysBridge(FilePath bridgeZipPath, FilePath bridgeInstallationPath) {
+    public void installSynopsysBridge(FilePath bridgeZipPath, FilePath bridgeInstallationPath) throws PluginExceptionHandler {
         try {
             if (bridgeZipPath != null && bridgeInstallationPath != null) {
+                logger.info("Unzipping Synopsys Bridge zip file from: %s", bridgeZipPath.getRemote());
                 bridgeZipPath.unzip(bridgeInstallationPath);
-                bridgeZipPath.delete();
-                logger.info(
-                        "Synopsys Bridge zip path: %s and bridge installation path: %s",
-                        bridgeZipPath.getRemote(), bridgeInstallationPath.getRemote());
+                logger.info("Synopsys Bridge installed successfully in: %", bridgeInstallationPath.getRemote());
             }
-        } catch (Exception e) {
+        } catch (IOException | InterruptedException e) {
             logger.error("An exception occurred while unzipping Synopsys Bridge zip file: " + e.getMessage());
-            Thread.currentThread().interrupt();
+            throw new PluginExceptionHandler(ErrorCode.SYNOPSYS_BRIDGE_UNZIPPING_FAILED);
+        }
+
+        // Deleting the bridge zip file after unzipping
+        try {
+            if (bridgeZipPath != null) {
+                bridgeZipPath.delete();
+            }
+        } catch (IOException | InterruptedException e) {
+            logger.warn("An exception occurred while deleting Synopsys Bridge zip file: " + e.getMessage());
         }
     }
 
@@ -50,7 +58,7 @@ public class BridgeInstall {
         try {
             defaultInstallationPath = workspace.act(new HomeDirectoryTask(separator));
         } catch (IOException | InterruptedException e) {
-            logger.error(LogMessages.FAILED_TO_FETCH_PLUGINS_DEFAULT_INSTALLATION_PATH, e.getMessage());
+            logger.error("Failed to fetch plugin's default installation path: %s", e.getMessage());
             Thread.currentThread().interrupt();
         }
 

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeInstall.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeInstall.java
@@ -19,7 +19,8 @@ public class BridgeInstall {
         this.logger = new LoggerWrapper(listener);
     }
 
-    public void installSynopsysBridge(FilePath bridgeZipPath, FilePath bridgeInstallationPath) throws PluginExceptionHandler {
+    public void installSynopsysBridge(FilePath bridgeZipPath, FilePath bridgeInstallationPath)
+            throws PluginExceptionHandler {
         try {
             if (bridgeZipPath != null && bridgeInstallationPath != null) {
                 logger.info("Unzipping Synopsys Bridge zip file from: %s", bridgeZipPath.getRemote());

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeInstall.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeInstall.java
@@ -24,7 +24,7 @@ public class BridgeInstall {
             if (bridgeZipPath != null && bridgeInstallationPath != null) {
                 logger.info("Unzipping Synopsys Bridge zip file from: %s", bridgeZipPath.getRemote());
                 bridgeZipPath.unzip(bridgeInstallationPath);
-                logger.info("Synopsys Bridge installed successfully in: %", bridgeInstallationPath.getRemote());
+                logger.info("Synopsys Bridge installed successfully in: %s", bridgeInstallationPath.getRemote());
             }
         } catch (IOException | InterruptedException e) {
             logger.error("An exception occurred while unzipping Synopsys Bridge zip file: " + e.getMessage());

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/exception/PluginExceptionHandler.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/exception/PluginExceptionHandler.java
@@ -12,6 +12,10 @@ public class PluginExceptionHandler extends Exception {
         super(message);
     }
 
+    public PluginExceptionHandler(int code) {
+        this.code = code;
+    }
+
     public PluginExceptionHandler(int code, String message) {
         super(message);
         this.code = code;

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/exception/PluginExceptionHandler.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/exception/PluginExceptionHandler.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.synopsys.security.scan.exception;
 
 public class PluginExceptionHandler extends Exception {
     private static final long serialVersionUID = 3172941819259598261L;
+    private int code;
 
     public PluginExceptionHandler() {
         super();
@@ -11,12 +12,21 @@ public class PluginExceptionHandler extends Exception {
         super(message);
     }
 
+    public PluginExceptionHandler(int code, String message) {
+        super(message);
+        this.code = code;
+    }
+
     public PluginExceptionHandler(Throwable cause) {
         super(cause);
     }
 
     public PluginExceptionHandler(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    public int getCode() {
+        return code;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/exception/ScannerException.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/exception/ScannerException.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.synopsys.security.scan.exception;
 
 public class ScannerException extends Exception {
     private static final long serialVersionUID = 3172941819259598261L;
-    private int code;
 
     public ScannerException() {
         super();
@@ -10,10 +9,5 @@ public class ScannerException extends Exception {
 
     public ScannerException(String message) {
         super(message);
-    }
-
-    public ScannerException(int code, String message) {
-        super(message);
-        this.code = code;
     }
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/exception/ScannerException.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/exception/ScannerException.java
@@ -10,4 +10,8 @@ public class ScannerException extends Exception {
     public ScannerException(String message) {
         super(message);
     }
+
+    public ScannerException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/exception/ScannerException.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/exception/ScannerException.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.synopsys.security.scan.exception;
 
 public class ScannerException extends Exception {
     private static final long serialVersionUID = 3172941819259598261L;
+    private int code;
 
     public ScannerException() {
         super();
@@ -9,5 +10,10 @@ public class ScannerException extends Exception {
 
     public ScannerException(String message) {
         super(message);
+    }
+
+    public ScannerException(int code, String message) {
+        super(message);
+        this.code = code;
     }
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/SecurityScan.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/SecurityScan.java
@@ -68,4 +68,6 @@ public interface SecurityScan {
     public Boolean isInclude_diagnostics();
 
     public Boolean isNetwork_airgap();
+
+    public Boolean isReturn_status();
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle.java
@@ -382,6 +382,11 @@ public class SecurityScanFreestyle extends Builder implements SecurityScan, Simp
         this.network_airgap = network_airgap ? true : null;
     }
 
+    @DataBoundSetter
+    public void setReturn_status(Boolean return_status) {
+        this.return_status = return_status ? true : null;
+    }
+
     private Map<String, Object> getParametersMap(FilePath workspace, TaskListener listener)
             throws PluginExceptionHandler {
         return ScanParametersFactory.preparePipelineParametersMap(

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle.java
@@ -411,7 +411,7 @@ public class SecurityScanFreestyle extends Builder implements SecurityScan, Simp
         } catch (Exception e) {
             if (e instanceof PluginExceptionHandler) {
                 throw new RuntimeException(
-                    ExceptionMessages.getErrorMessage(((PluginExceptionHandler) e).getCode(), e.getMessage()));
+                        ExceptionMessages.getErrorMessage(((PluginExceptionHandler) e).getCode(), e.getMessage()));
             } else {
                 throw new RuntimeException(e.getMessage(), e);
             }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep.java
@@ -494,7 +494,7 @@ public class SecurityScanStep extends Step implements Serializable {
                     exitCode = ((PluginExceptionHandler) e).getCode();
                     handleExitCode(exitCode, logger, null);
                 } else {
-                    exitCode = ErrorCode.UNKNOWN_PLUGIN_ERROR;
+                    exitCode = ErrorCode.UNDEFINED_PLUGIN_ERROR;
                     handleExitCode(exitCode, logger, e.getMessage());
                 }
             } finally {
@@ -519,8 +519,8 @@ public class SecurityScanStep extends Step implements Serializable {
 
             logger.error(errorMessage);
 
-            if (!isReturn_status() && exitCode == ErrorCode.UNKNOWN_PLUGIN_ERROR) {
-                // Throw exception with stack trace for unknown errors
+            if (!isReturn_status() && exitCode == ErrorCode.UNDEFINED_PLUGIN_ERROR) {
+                // Throw exception with stack trace for undefined errors
                 throw new ScannerException(ExceptionMessages.scannerFailureMessage(unknownErrorMessage));
             } else if (!isReturn_status()) {
                 throw new PluginExceptionHandler(errorMessage);

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep.java
@@ -487,7 +487,8 @@ public class SecurityScanStep extends Step implements Serializable {
                     "**************************** START EXECUTION OF SYNOPSYS SECURITY SCAN ****************************");
 
             try {
-                exitCode = ScanParametersFactory.createPipelineCommand(run, listener, envVars, launcher, node, workspace)
+                exitCode = ScanParametersFactory.createPipelineCommand(
+                                run, listener, envVars, launcher, node, workspace)
                         .initializeScanner(getParametersMap(workspace, listener));
             } catch (Exception e) {
                 if (e instanceof PluginExceptionHandler) {
@@ -499,9 +500,9 @@ public class SecurityScanStep extends Step implements Serializable {
             } finally {
                 String errorMessage = ExceptionMessages.getErrorMessage(exitCode, undefinedErrorMessage);
                 logger.error(errorMessage);
-                
+
                 logger.println(
-                    "**************************** END EXECUTION OF SYNOPSYS SECURITY SCAN ****************************");
+                        "**************************** END EXECUTION OF SYNOPSYS SECURITY SCAN ****************************");
 
                 handleExitCode(exitCode, errorMessage);
             }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep.java
@@ -549,7 +549,7 @@ public class SecurityScanStep extends Step implements SecurityScan, Serializable
                                         ApplicationConstants.GITLAB_BRANCH_SOURCE_PLUGIN_NAME, false)
                                 && scmSource instanceof GitLabSCMSource))) {
                     logger.error("Necessary 'Branch Source Plugin' is not installed in Jenkins instance. "
-                            + "Please install necessary 'Branch Source Plugin' in your jenkins instance");
+                            + "Please install necessary 'Branch Source Plugin' in your Jenkins instance");
                     throw new PluginExceptionHandler(ErrorCode.REQUIRED_BRANCH_SOURCE_PLUGIN_NOT_INSTALLED);
                 }
             }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep.java
@@ -482,6 +482,7 @@ public class SecurityScanStep extends Step implements Serializable {
             LoggerWrapper logger = new LoggerWrapper(listener);
             int exitCode = 0;
             String undefinedErrorMessage = null;
+            Exception unknownException = new Exception();
 
             logger.println(
                     "**************************** START EXECUTION OF SYNOPSYS SECURITY SCAN ****************************");
@@ -496,6 +497,7 @@ public class SecurityScanStep extends Step implements Serializable {
                 } else {
                     exitCode = ErrorCode.UNDEFINED_PLUGIN_ERROR;
                     undefinedErrorMessage = e.getMessage();
+                    unknownException = e;
                 }
             } finally {
                 String errorMessage = ExceptionMessages.getErrorMessage(exitCode, undefinedErrorMessage);
@@ -504,14 +506,15 @@ public class SecurityScanStep extends Step implements Serializable {
                 logger.println(
                         "**************************** END EXECUTION OF SYNOPSYS SECURITY SCAN ****************************");
 
-                handleExitCode(exitCode, errorMessage);
+                handleExitCode(exitCode, errorMessage, unknownException);
             }
 
             return exitCode;
         }
     }
 
-    private void handleExitCode(int exitCode, String errorMessage) throws PluginExceptionHandler, ScannerException {
+    private void handleExitCode(int exitCode, String errorMessage, Exception e)
+            throws PluginExceptionHandler, ScannerException {
         if (exitCode != 0) {
             if (Objects.equals(isReturn_status(), true)) {
                 return;
@@ -519,7 +522,7 @@ public class SecurityScanStep extends Step implements Serializable {
 
             if (exitCode == ErrorCode.UNDEFINED_PLUGIN_ERROR) {
                 // Throw exception with stack trace for undefined errors
-                throw new ScannerException(errorMessage);
+                throw new ScannerException(errorMessage, e);
             }
 
             throw new PluginExceptionHandler(errorMessage);

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactory.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactory.java
@@ -75,9 +75,13 @@ public class ScanParametersFactory {
 
             parametersMap.putAll(prepareBridgeParametersMap(scanStep));
 
+            if (scanStep.isReturn_status() != null) {
+                parametersMap.put(ApplicationConstants.RETURN_STATUS_KEY, scanStep.isReturn_status());
+            }
+
             return parametersMap;
         } else {
-            throw new PluginExceptionHandler(LogMessages.INVALID_SYNOPSYS_SECURITY_PRODUCT);
+            throw new PluginExceptionHandler(ErrorCode.PARAMETER_VALIDATION_FAILED, LogMessages.INVALID_SYNOPSYS_SECURITY_PRODUCT);
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactory.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactory.java
@@ -379,7 +379,8 @@ public class ScanParametersFactory {
 
         if (!isValid) {
             logger.error("Invalid Synopsys Security Product");
-            logger.info("Supported values for Synopsys security products: " + Arrays.toString(SecurityProduct.values()));
+            logger.info(
+                    "Supported values for Synopsys security products: " + Arrays.toString(SecurityProduct.values()));
         }
 
         return isValid;

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactory.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactory.java
@@ -81,7 +81,8 @@ public class ScanParametersFactory {
 
             return parametersMap;
         } else {
-            throw new PluginExceptionHandler(ErrorCode.PARAMETER_VALIDATION_FAILED, LogMessages.INVALID_SYNOPSYS_SECURITY_PRODUCT);
+            throw new PluginExceptionHandler(
+                    ErrorCode.PARAMETER_VALIDATION_FAILED, LogMessages.INVALID_SYNOPSYS_SECURITY_PRODUCT);
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactory.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactory.java
@@ -76,14 +76,13 @@ public class ScanParametersFactory {
 
             parametersMap.putAll(prepareBridgeParametersMap(securityScan));
 
-            if (scanStep.isReturn_status() != null) {
-                parametersMap.put(ApplicationConstants.RETURN_STATUS_KEY, scanStep.isReturn_status());
+            if (securityScan.isReturn_status() != null) {
+                parametersMap.put(ApplicationConstants.RETURN_STATUS_KEY, securityScan.isReturn_status());
             }
 
             return parametersMap;
         } else {
-            throw new PluginExceptionHandler(
-                    ErrorCode.PARAMETER_VALIDATION_FAILED, LogMessages.INVALID_SYNOPSYS_SECURITY_PRODUCT);
+            throw new PluginExceptionHandler(ErrorCode.INVALID_SECURITY_PRODUCT);
         }
     }
 
@@ -379,8 +378,8 @@ public class ScanParametersFactory {
                                 || p.equals(SecurityProduct.COVERITY.name()));
 
         if (!isValid) {
-            logger.error(LogMessages.INVALID_SYNOPSYS_SECURITY_PRODUCT);
-            logger.info("Supported Synopsys Security Products: " + Arrays.toString(SecurityProduct.values()));
+            logger.error("Invalid Synopsys Security Product");
+            logger.info("Supported values for Synopsys security products: " + Arrays.toString(SecurityProduct.values()));
         }
 
         return isValid;

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ApplicationConstants.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ApplicationConstants.java
@@ -60,6 +60,7 @@ public class ApplicationConstants {
     public static final String INCLUDE_DIAGNOSTICS_KEY = "include_diagnostics";
 
     public static final String NETWORK_AIRGAP_KEY = "network_airgap";
+    public static final String RETURN_STATUS_KEY = "return_status";
 
     public static final String BITBUCKET_TOKEN_KEY = "bitbucket_token";
     public static final String GITHUB_TOKEN_KEY = "github_token";

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ErrorCode.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ErrorCode.java
@@ -1,0 +1,18 @@
+package io.jenkins.plugins.synopsys.security.scan.global;
+
+public class ErrorCode {
+    //Bridge specific error codes
+    public static int BRIDGE_UNDEFINED_ERROR = 1;
+    public static int BRIDGE_ADAPTER_ERROR = 2;
+    public static int BRIDGE_SHUTDOWN_FAILED = 3;
+    public static int BRIDGE_BUILD_BREAK = 8;
+    public static int BRIDGE_STARTUP_FAILED = 9;
+
+    //Plugin specific error codes
+    public static int PARAMETER_VALIDATION_FAILED = 31;
+    public static int BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED = 32;
+    public static int BRIDGE_EXECUTABLE_NOT_FOUND = 33;
+    public static int SCM_TOKEN_NOT_FOUND = 34;
+    public static int SCM_URL_VALIDATION_FAILED = 35;
+    public static int UNKNOWN_PLUGIN_ERROR = 36;
+}

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ErrorCode.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ErrorCode.java
@@ -23,5 +23,6 @@ public class ErrorCode {
     public static final int NO_GITLAB_TOKEN_FOUND = 112;
     public static final int INVALID_GITHUB_URL = 113;
     public static final int INVALID_GITLAB_URL = 114;
+    public static final int REQUIRED_BRANCH_SOURCE_PLUGIN_NOT_INSTALLED = 115;
     public static final int UNDEFINED_PLUGIN_ERROR = 999;
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ErrorCode.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ErrorCode.java
@@ -10,9 +10,9 @@ public class ErrorCode {
 
     //Plugin specific error codes
     public static int PARAMETER_VALIDATION_FAILED = 31;
-    public static int BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED = 32;
-    public static int BRIDGE_EXECUTABLE_NOT_FOUND = 33;
+    public static int SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED = 32;
+    public static int SYNOPSYS_BRIDGE_EXECUTABLE_NOT_FOUND = 33;
     public static int SCM_TOKEN_NOT_FOUND = 34;
     public static int SCM_URL_VALIDATION_FAILED = 35;
-    public static int UNKNOWN_PLUGIN_ERROR = 36;
+    public static int UNDEFINED_PLUGIN_ERROR = 36;
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ErrorCode.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ErrorCode.java
@@ -2,17 +2,17 @@ package io.jenkins.plugins.synopsys.security.scan.global;
 
 public class ErrorCode {
     // Bridge specific error codes
-    public static int BRIDGE_UNDEFINED_ERROR = 1;
-    public static int BRIDGE_ADAPTER_ERROR = 2;
-    public static int BRIDGE_SHUTDOWN_FAILED = 3;
-    public static int BRIDGE_BUILD_BREAK = 8;
-    public static int BRIDGE_STARTUP_FAILED = 9;
+    public static final int BRIDGE_UNDEFINED_ERROR = 1;
+    public static final int BRIDGE_ADAPTER_ERROR = 2;
+    public static final int BRIDGE_SHUTDOWN_FAILED = 3;
+    public static final int BRIDGE_BUILD_BREAK = 8;
+    public static final int BRIDGE_STARTUP_FAILED = 9;
 
     // Plugin specific error codes
-    public static int PARAMETER_VALIDATION_FAILED = 31;
-    public static int SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED = 32;
-    public static int SYNOPSYS_BRIDGE_EXECUTABLE_NOT_FOUND = 33;
-    public static int SCM_TOKEN_NOT_FOUND = 34;
-    public static int SCM_URL_VALIDATION_FAILED = 35;
-    public static int UNDEFINED_PLUGIN_ERROR = 36;
+    public static final int PARAMETER_VALIDATION_FAILED = 31;
+    public static final int SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED = 32;
+    public static final int SYNOPSYS_BRIDGE_EXECUTABLE_NOT_FOUND = 33;
+    public static final int SCM_TOKEN_NOT_FOUND = 34;
+    public static final int SCM_URL_VALIDATION_FAILED = 35;
+    public static final int UNDEFINED_PLUGIN_ERROR = 36;
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ErrorCode.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ErrorCode.java
@@ -9,10 +9,19 @@ public class ErrorCode {
     public static final int BRIDGE_STARTUP_FAILED = 9;
 
     // Plugin specific error codes
-    public static final int PARAMETER_VALIDATION_FAILED = 31;
-    public static final int SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED = 32;
-    public static final int SYNOPSYS_BRIDGE_EXECUTABLE_NOT_FOUND = 33;
-    public static final int SCM_TOKEN_NOT_FOUND = 34;
-    public static final int SCM_URL_VALIDATION_FAILED = 35;
-    public static final int UNDEFINED_PLUGIN_ERROR = 36;
+    public static final int INVALID_SECURITY_PRODUCT = 101;
+    public static final int INVALID_BLACKDUCK_PARAMETERS = 102;
+    public static final int INVALID_COVERITY_PARAMETERS = 103;
+    public static final int INVALID_POLARIS_PARAMETERS = 104;
+    public static final int INVALID_BRIDGE_DOWNLOAD_PARAMETERS = 105;
+    public static final int SYNOPSYS_BRIDGE_DOWNLOAD_FAILED = 106;
+    public static final int SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY = 107;
+    public static final int SYNOPSYS_BRIDGE_UNZIPPING_FAILED = 108;
+    public static final int SYNOPSYS_BRIDGE_NOT_FOUND_IN_PROVIDED_PATH = 109;
+    public static final int NO_BITBUCKET_TOKEN_FOUND = 110;
+    public static final int NO_GITHUB_TOKEN_FOUND = 111;
+    public static final int NO_GITLAB_TOKEN_FOUND = 112;
+    public static final int INVALID_GITHUB_URL = 113;
+    public static final int INVALID_GITLAB_URL = 114;
+    public static final int UNDEFINED_PLUGIN_ERROR = 999;
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ErrorCode.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ErrorCode.java
@@ -1,14 +1,14 @@
 package io.jenkins.plugins.synopsys.security.scan.global;
 
 public class ErrorCode {
-    //Bridge specific error codes
+    // Bridge specific error codes
     public static int BRIDGE_UNDEFINED_ERROR = 1;
     public static int BRIDGE_ADAPTER_ERROR = 2;
     public static int BRIDGE_SHUTDOWN_FAILED = 3;
     public static int BRIDGE_BUILD_BREAK = 8;
     public static int BRIDGE_STARTUP_FAILED = 9;
 
-    //Plugin specific error codes
+    // Plugin specific error codes
     public static int PARAMETER_VALIDATION_FAILED = 31;
     public static int SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED = 32;
     public static int SYNOPSYS_BRIDGE_EXECUTABLE_NOT_FOUND = 33;

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ExceptionMessages.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ExceptionMessages.java
@@ -6,14 +6,6 @@ import java.util.Map;
 public class ExceptionMessages {
     public static final String NULL_WORKSPACE = "Detect cannot be executed when the workspace is null";
 
-    public static String scannerFailedWithExitCode(int exitCode) {
-        return "Synopsys Security Scan failed with unknown exit code " + exitCode;
-    }
-
-    public static String scannerFailureMessage(String message) {
-        return "Synopsys Security Scan failed!! " + message;
-    }
-
     public static Map<Integer, String> getExitCodeToMessageMap() {
         Map<Integer, String> exitCodeToMessage = new HashMap<>();
 
@@ -28,8 +20,26 @@ public class ExceptionMessages {
         exitCodeToMessage.put(ErrorCode.SYNOPSYS_BRIDGE_EXECUTABLE_NOT_FOUND, "Synopsys bridge executable not found in installation path");
         exitCodeToMessage.put(ErrorCode.SCM_TOKEN_NOT_FOUND, "SCM token not found");
         exitCodeToMessage.put(ErrorCode.SCM_URL_VALIDATION_FAILED, "SCM URL validation failed");
-        exitCodeToMessage.put(ErrorCode.UNDEFINED_PLUGIN_ERROR, "Undefined plugin error, check error logs");
+        exitCodeToMessage.put(ErrorCode.UNDEFINED_PLUGIN_ERROR, "Undefined plugin error");
 
         return exitCodeToMessage;
+    }
+
+    public static String getErrorMessage(int exitCode, String undefinedErrorMessage) {
+        String errorMessage;
+        Map<Integer, String> exitCodeToMessage = ExceptionMessages.getExitCodeToMessageMap();
+        if (exitCodeToMessage.containsKey(exitCode)) {
+            if (exitCode == ErrorCode.UNDEFINED_PLUGIN_ERROR) {
+                errorMessage = "Workflow failed! Exit code " +
+                    exitCode + ": " + exitCodeToMessage.get(exitCode) +
+                    " - " + undefinedErrorMessage;
+            } else {
+                errorMessage = "Workflow failed! Exit code " +
+                    exitCode + ": " + exitCodeToMessage.get(exitCode);
+            }
+        } else {
+            errorMessage = "Synopsys Security Scan failed! Reason: " + undefinedErrorMessage;
+        }
+        return errorMessage;
     }
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ExceptionMessages.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ExceptionMessages.java
@@ -34,6 +34,9 @@ public class ExceptionMessages {
         exitCodeToMessage.put(ErrorCode.INVALID_GITHUB_URL, "Invalid GitHub repository URL");
         exitCodeToMessage.put(ErrorCode.INVALID_GITLAB_URL, "Invalid GitLab repository URL");
         exitCodeToMessage.put(ErrorCode.UNDEFINED_PLUGIN_ERROR, "Undefined plugin error");
+        exitCodeToMessage.put(
+                ErrorCode.REQUIRED_BRANCH_SOURCE_PLUGIN_NOT_INSTALLED,
+                "Necessary 'Branch Source Plugin' is not installed in Jenkins instance");
 
         return exitCodeToMessage;
     }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ExceptionMessages.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ExceptionMessages.java
@@ -15,15 +15,20 @@ public class ExceptionMessages {
         exitCodeToMessage.put(ErrorCode.BRIDGE_BUILD_BREAK, "The config option 'bridge.break' has been set to true");
         exitCodeToMessage.put(ErrorCode.BRIDGE_STARTUP_FAILED, "Bridge initialization failed");
 
-        exitCodeToMessage.put(ErrorCode.PARAMETER_VALIDATION_FAILED, "Scan parameter validation failed");
-        exitCodeToMessage.put(
-                ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED,
-                "Synopsys bridge download or installation failed");
-        exitCodeToMessage.put(
-                ErrorCode.SYNOPSYS_BRIDGE_EXECUTABLE_NOT_FOUND,
-                "Synopsys bridge executable not found in installation path");
-        exitCodeToMessage.put(ErrorCode.SCM_TOKEN_NOT_FOUND, "SCM token not found");
-        exitCodeToMessage.put(ErrorCode.SCM_URL_VALIDATION_FAILED, "SCM URL validation failed");
+        exitCodeToMessage.put(ErrorCode.INVALID_SECURITY_PRODUCT, "Invalid Synopsys Security Product");
+        exitCodeToMessage.put(ErrorCode.INVALID_BLACKDUCK_PARAMETERS, "Invalid BlackDuck parameters");
+        exitCodeToMessage.put(ErrorCode.INVALID_COVERITY_PARAMETERS, "Invalid Coverity parameters");
+        exitCodeToMessage.put(ErrorCode.INVALID_POLARIS_PARAMETERS, "Invalid Polaris parameters");
+        exitCodeToMessage.put(ErrorCode.INVALID_BRIDGE_DOWNLOAD_PARAMETERS, "Bridge download parameters are not valid");
+        exitCodeToMessage.put(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED, "Synopsys Bridge download failed");
+        exitCodeToMessage.put(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY, "Synopsys Bridge download failed and will not retry to download");
+        exitCodeToMessage.put(ErrorCode.SYNOPSYS_BRIDGE_UNZIPPING_FAILED, "Synopsys Bridge unzipping failed");
+        exitCodeToMessage.put(ErrorCode.SYNOPSYS_BRIDGE_NOT_FOUND_IN_PROVIDED_PATH, "Synopsys Bridge could not be found in provided path");
+        exitCodeToMessage.put(ErrorCode.NO_BITBUCKET_TOKEN_FOUND, "No Bitbucket token found");
+        exitCodeToMessage.put(ErrorCode.NO_GITHUB_TOKEN_FOUND, "No GitHub token found");
+        exitCodeToMessage.put(ErrorCode.NO_GITLAB_TOKEN_FOUND, "No GitLab token found");
+        exitCodeToMessage.put(ErrorCode.INVALID_GITHUB_URL, "Invalid GitHub repository URL");
+        exitCodeToMessage.put(ErrorCode.INVALID_GITLAB_URL, "Invalid GitLab repository URL");
         exitCodeToMessage.put(ErrorCode.UNDEFINED_PLUGIN_ERROR, "Undefined plugin error");
 
         return exitCodeToMessage;

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ExceptionMessages.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ExceptionMessages.java
@@ -21,9 +21,13 @@ public class ExceptionMessages {
         exitCodeToMessage.put(ErrorCode.INVALID_POLARIS_PARAMETERS, "Invalid Polaris parameters");
         exitCodeToMessage.put(ErrorCode.INVALID_BRIDGE_DOWNLOAD_PARAMETERS, "Bridge download parameters are not valid");
         exitCodeToMessage.put(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED, "Synopsys Bridge download failed");
-        exitCodeToMessage.put(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY, "Synopsys Bridge download failed and will not retry to download");
+        exitCodeToMessage.put(
+                ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY,
+                "Synopsys Bridge download failed and will not retry to download");
         exitCodeToMessage.put(ErrorCode.SYNOPSYS_BRIDGE_UNZIPPING_FAILED, "Synopsys Bridge unzipping failed");
-        exitCodeToMessage.put(ErrorCode.SYNOPSYS_BRIDGE_NOT_FOUND_IN_PROVIDED_PATH, "Synopsys Bridge could not be found in provided path");
+        exitCodeToMessage.put(
+                ErrorCode.SYNOPSYS_BRIDGE_NOT_FOUND_IN_PROVIDED_PATH,
+                "Synopsys Bridge could not be found in provided path");
         exitCodeToMessage.put(ErrorCode.NO_BITBUCKET_TOKEN_FOUND, "No Bitbucket token found");
         exitCodeToMessage.put(ErrorCode.NO_GITHUB_TOKEN_FOUND, "No GitHub token found");
         exitCodeToMessage.put(ErrorCode.NO_GITLAB_TOKEN_FOUND, "No GitLab token found");

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ExceptionMessages.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ExceptionMessages.java
@@ -16,8 +16,12 @@ public class ExceptionMessages {
         exitCodeToMessage.put(ErrorCode.BRIDGE_STARTUP_FAILED, "Bridge initialization failed");
 
         exitCodeToMessage.put(ErrorCode.PARAMETER_VALIDATION_FAILED, "Scan parameter validation failed");
-        exitCodeToMessage.put(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, "Synopsys bridge download or installation failed");
-        exitCodeToMessage.put(ErrorCode.SYNOPSYS_BRIDGE_EXECUTABLE_NOT_FOUND, "Synopsys bridge executable not found in installation path");
+        exitCodeToMessage.put(
+                ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED,
+                "Synopsys bridge download or installation failed");
+        exitCodeToMessage.put(
+                ErrorCode.SYNOPSYS_BRIDGE_EXECUTABLE_NOT_FOUND,
+                "Synopsys bridge executable not found in installation path");
         exitCodeToMessage.put(ErrorCode.SCM_TOKEN_NOT_FOUND, "SCM token not found");
         exitCodeToMessage.put(ErrorCode.SCM_URL_VALIDATION_FAILED, "SCM URL validation failed");
         exitCodeToMessage.put(ErrorCode.UNDEFINED_PLUGIN_ERROR, "Undefined plugin error");
@@ -30,12 +34,11 @@ public class ExceptionMessages {
         Map<Integer, String> exitCodeToMessage = ExceptionMessages.getExitCodeToMessageMap();
         if (exitCodeToMessage.containsKey(exitCode)) {
             if (exitCode == ErrorCode.UNDEFINED_PLUGIN_ERROR) {
-                errorMessage = "Workflow failed! Exit code " +
-                    exitCode + ": " + exitCodeToMessage.get(exitCode) +
-                    " - " + undefinedErrorMessage;
+                errorMessage = "Workflow failed! Exit code " + exitCode
+                        + ": " + exitCodeToMessage.get(exitCode) + " - "
+                        + undefinedErrorMessage;
             } else {
-                errorMessage = "Workflow failed! Exit code " +
-                    exitCode + ": " + exitCodeToMessage.get(exitCode);
+                errorMessage = "Workflow failed! Exit code " + exitCode + ": " + exitCodeToMessage.get(exitCode);
             }
         } else {
             errorMessage = "Synopsys Security Scan failed! Reason: " + undefinedErrorMessage;

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ExceptionMessages.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ExceptionMessages.java
@@ -7,21 +7,23 @@ public class ExceptionMessages {
     public static final String NULL_WORKSPACE = "Detect cannot be executed when the workspace is null";
 
     public static String scannerFailedWithExitCode(int exitCode) {
-        return "Synopsys Security Scan failed with exit code " + exitCode;
+        return "Synopsys Security Scan failed with unknown exit code " + exitCode;
     }
 
     public static String scannerFailureMessage(String message) {
         return "Synopsys Security Scan failed!! " + message;
     }
 
-    public static Map<Integer, String> bridgeErrorMessages() {
+    public static Map<Integer, String> getExitCodeToMessageMap() {
         Map<Integer, String> exitCodeToMessage = new HashMap<>();
 
-        exitCodeToMessage.put(1, "Workflow failed! Exit Code: 1 Undefined error, check error logs");
-        exitCodeToMessage.put(2, "Workflow failed! Exit Code: 2 Error from adapter");
-        exitCodeToMessage.put(3, "Workflow failed! Exit Code: 3 Failed to shutdown the Bridge");
-        exitCodeToMessage.put(8, "Workflow failed! Exit Code: 8 The config option bridge.break has been set to true");
-        exitCodeToMessage.put(9, "Workflow failed! Exit Code: 9 Bridge initialization failed");
+        exitCodeToMessage.put(ErrorCode.BRIDGE_UNDEFINED_ERROR, "Undefined error, check error logs");
+        exitCodeToMessage.put(ErrorCode.BRIDGE_ADAPTER_ERROR, "Error from adapter");
+        exitCodeToMessage.put(ErrorCode.BRIDGE_SHUTDOWN_FAILED, "Failed to shutdown the Bridge");
+        exitCodeToMessage.put(ErrorCode.BRIDGE_BUILD_BREAK, "The config option bridge.break has been set to true");
+        exitCodeToMessage.put(ErrorCode.BRIDGE_STARTUP_FAILED, "Bridge initialization failed");
+
+        exitCodeToMessage.put(ErrorCode.PARAMETER_VALIDATION_FAILED, "Parameter validation failed");
 
         return exitCodeToMessage;
     }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ExceptionMessages.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ExceptionMessages.java
@@ -20,10 +20,15 @@ public class ExceptionMessages {
         exitCodeToMessage.put(ErrorCode.BRIDGE_UNDEFINED_ERROR, "Undefined error, check error logs");
         exitCodeToMessage.put(ErrorCode.BRIDGE_ADAPTER_ERROR, "Error from adapter");
         exitCodeToMessage.put(ErrorCode.BRIDGE_SHUTDOWN_FAILED, "Failed to shutdown the Bridge");
-        exitCodeToMessage.put(ErrorCode.BRIDGE_BUILD_BREAK, "The config option bridge.break has been set to true");
+        exitCodeToMessage.put(ErrorCode.BRIDGE_BUILD_BREAK, "The config option 'bridge.break' has been set to true");
         exitCodeToMessage.put(ErrorCode.BRIDGE_STARTUP_FAILED, "Bridge initialization failed");
 
-        exitCodeToMessage.put(ErrorCode.PARAMETER_VALIDATION_FAILED, "Parameter validation failed");
+        exitCodeToMessage.put(ErrorCode.PARAMETER_VALIDATION_FAILED, "Scan parameter validation failed");
+        exitCodeToMessage.put(ErrorCode.SYNOPSYS_BRIDGE_DOWNLOAD_OR_INSTALLATION_FAILED, "Synopsys bridge download or installation failed");
+        exitCodeToMessage.put(ErrorCode.SYNOPSYS_BRIDGE_EXECUTABLE_NOT_FOUND, "Synopsys bridge executable not found in installation path");
+        exitCodeToMessage.put(ErrorCode.SCM_TOKEN_NOT_FOUND, "SCM token not found");
+        exitCodeToMessage.put(ErrorCode.SCM_URL_VALIDATION_FAILED, "SCM URL validation failed");
+        exitCodeToMessage.put(ErrorCode.UNDEFINED_PLUGIN_ERROR, "Undefined plugin error, check error logs");
 
         return exitCodeToMessage;
     }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/LogMessages.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/LogMessages.java
@@ -26,8 +26,10 @@ public class LogMessages {
             "An exception occurred while installing/downloading synopsys-bridge: %s";
     public static final String INVALID_SYNOPSYS_SECURITY_PRODUCT = "Invalid Synopsys Security Product!";
     public static final String SYNOPSYS_BRIDGE_DOWNLOAD_FAILED = "Synopsys bridge download failed!";
-    public static final String SYNOPSYS_BRIDGE_DOWNLOAD_RETRY_INTERRUPTED = "Interrupted while waiting to retry Synopsys Bridge download";
-    public static final String SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY = "Synopsys Bridge download failed with status code: %s and plugin won't retry to download.";
+    public static final String SYNOPSYS_BRIDGE_DOWNLOAD_RETRY_INTERRUPTED =
+            "Interrupted while waiting to retry Synopsys Bridge download";
+    public static final String SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY =
+            "Synopsys Bridge download failed with status code: %s and plugin won't retry to download.";
     public static final String JENKINS_INSTANCE_MISSING_WARNING =
             "Connection validation could not be completed: Validation couldn't retrieve the instance of Jenkins from the JVM. This may happen if Jenkins is still starting up or if this code is running on a different JVM than your Jenkins server.";
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/LogMessages.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/LogMessages.java
@@ -26,6 +26,8 @@ public class LogMessages {
             "An exception occurred while installing/downloading synopsys-bridge: %s";
     public static final String INVALID_SYNOPSYS_SECURITY_PRODUCT = "Invalid Synopsys Security Product!";
     public static final String SYNOPSYS_BRIDGE_DOWNLOAD_FAILED = "Synopsys bridge download failed!";
+    public static final String SYNOPSYS_BRIDGE_DOWNLOAD_RETRY_INTERRUPTED = "Interrupted while waiting to retry Synopsys Bridge download";
+    public static final String SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY = "Synopsys Bridge download failed with status code: %s and plugin won't retry to download.";
     public static final String JENKINS_INSTANCE_MISSING_WARNING =
             "Connection validation could not be completed: Validation couldn't retrieve the instance of Jenkins from the JVM. This may happen if Jenkins is still starting up or if this code is running on a different JVM than your Jenkins server.";
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/LogMessages.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/LogMessages.java
@@ -5,31 +5,6 @@ public class LogMessages {
             "******************************************************************************";
     public static final String DASHES =
             "------------------------------------------------------------------------------------";
-    public static final String INVALID_SYNOPSYS_BRIDGE_DOWNLOAD_URL = "Invalid Synopsys Bridge download URL: %s";
-    public static final String FAILED_TO_FETCH_PLUGINS_DEFAULT_INSTALLATION_PATH =
-            "Failed to fetch plugin's default installation path: %s";
-    public static final String BLACKDUCK_PARAMETER_VALIDATION_FAILED = "BlackDuck parameters are not valid";
-    public static final String COVERITY_PARAMETER_VALIDATION_FAILED = "Coverity parameters are not valid";
-    public static final String POLARIS_PARAMETER_VALIDATION_FAILED = "Polaris parameters are not valid";
-    public static final String NO_BITBUCKET_TOKEN_FOUND = "PrComment is set true but no Bitbucket token found!";
-    public static final String NO_GITHUB_TOKEN_FOUND = "PrComment is set true but no Github token found!";
-    public static final String NO_GITLAB_TOKEN_FOUND = "PrComment is set true but no Gitlab token found!";
-    public static final String INVALID_BRIDGE_DOWNLOAD_PARAMETERS = "Bridge download parameters are not valid";
-    public static final String EMPTY_BRIDGE_DOWNLOAD_URL_PROVIDED = "The provided Bridge download URL is empty";
-    public static final String INVALID_BRIDGE_DOWNLOAD_URL_PROVIDED =
-            "The provided Bridge download URL is not valid: %s";
-    public static final String INVALID_BRIDGE_DOWNLOAD_VERSION_PROVIDED =
-            "The provided Bridge download version is not valid: %s";
-    public static final String EXCEPTION_OCCURRED_WHILE_INVOKING_SYNOPSYS_BRIDGE =
-            "An exception occurred while invoking synopsys-bridge from the plugin: %s";
-    public static final String EXCEPTION_OCCURRED_WHILE_DOWNLOADING_OR_INSTALLING_SYNOPSYS_BRIDGE =
-            "An exception occurred while installing/downloading synopsys-bridge: %s";
-    public static final String INVALID_SYNOPSYS_SECURITY_PRODUCT = "Invalid Synopsys Security Product!";
-    public static final String SYNOPSYS_BRIDGE_DOWNLOAD_FAILED = "Synopsys bridge download failed!";
-    public static final String SYNOPSYS_BRIDGE_DOWNLOAD_RETRY_INTERRUPTED =
-            "Interrupted while waiting to retry Synopsys Bridge download";
-    public static final String SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WONT_RETRY =
-            "Synopsys Bridge download failed with status code: %s and plugin won't retry to download.";
     public static final String JENKINS_INSTANCE_MISSING_WARNING =
             "Connection validation could not be completed: Validation couldn't retrieve the instance of Jenkins from the JVM. This may happen if Jenkins is still starting up or if this code is running on a different JVM than your Jenkins server.";
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/Utility.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/Utility.java
@@ -184,15 +184,18 @@ public class Utility {
 
     public static Map<String, Boolean> installedBranchSourceDependencies() {
         Map<String, Boolean> installedBranchSourceDependencies = new HashMap<>();
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
 
-        if (Jenkins.getInstance().getPlugin(ApplicationConstants.BITBUCKET_BRANCH_SOURCE_PLUGIN_NAME) != null) {
-            installedBranchSourceDependencies.put(ApplicationConstants.BITBUCKET_BRANCH_SOURCE_PLUGIN_NAME, true);
-        }
-        if (Jenkins.getInstance().getPlugin(ApplicationConstants.GITHUB_BRANCH_SOURCE_PLUGIN_NAME) != null) {
-            installedBranchSourceDependencies.put(ApplicationConstants.GITHUB_BRANCH_SOURCE_PLUGIN_NAME, true);
-        }
-        if (Jenkins.getInstance().getPlugin(ApplicationConstants.GITLAB_BRANCH_SOURCE_PLUGIN_NAME) != null) {
-            installedBranchSourceDependencies.put(ApplicationConstants.GITLAB_BRANCH_SOURCE_PLUGIN_NAME, true);
+        if (jenkins != null) {
+            if (jenkins.getPlugin(ApplicationConstants.BITBUCKET_BRANCH_SOURCE_PLUGIN_NAME) != null) {
+                installedBranchSourceDependencies.put(ApplicationConstants.BITBUCKET_BRANCH_SOURCE_PLUGIN_NAME, true);
+            }
+            if (jenkins.getPlugin(ApplicationConstants.GITHUB_BRANCH_SOURCE_PLUGIN_NAME) != null) {
+                installedBranchSourceDependencies.put(ApplicationConstants.GITHUB_BRANCH_SOURCE_PLUGIN_NAME, true);
+            }
+            if (jenkins.getPlugin(ApplicationConstants.GITLAB_BRANCH_SOURCE_PLUGIN_NAME) != null) {
+                installedBranchSourceDependencies.put(ApplicationConstants.GITLAB_BRANCH_SOURCE_PLUGIN_NAME, true);
+            }
         }
 
         return installedBranchSourceDependencies;

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParametersService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParametersService.java
@@ -28,7 +28,7 @@ public class BridgeDownloadParametersService {
     }
 
     public boolean performBridgeDownloadParameterValidation(BridgeDownloadParameters bridgeDownloadParameters)
-        throws PluginExceptionHandler {
+            throws PluginExceptionHandler {
         boolean validUrl = isValidUrl(bridgeDownloadParameters.getBridgeDownloadUrl());
         boolean validVersion = isValidVersion(bridgeDownloadParameters.getBridgeDownloadVersion());
         boolean validInstallationPath = isValidInstallationPath(bridgeDownloadParameters.getBridgeInstallationPath());

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParametersService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParametersService.java
@@ -108,7 +108,7 @@ public class BridgeDownloadParametersService {
         }
 
         boolean isNetworkAirgap = scanParameters.containsKey(ApplicationConstants.NETWORK_AIRGAP_KEY)
-                && ((Boolean) scanParameters.get(ApplicationConstants.NETWORK_AIRGAP_KEY)).equals(true);
+                && scanParameters.get(ApplicationConstants.NETWORK_AIRGAP_KEY).equals(true);
 
         if (scanParameters.containsKey(ApplicationConstants.SYNOPSYS_BRIDGE_DOWNLOAD_URL)) {
             bridgeDownloadParameters.setBridgeDownloadUrl(scanParameters

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scan/ScanParametersService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scan/ScanParametersService.java
@@ -20,8 +20,7 @@ public class ScanParametersService {
         this.listener = listener;
     }
 
-    public boolean performScanParameterValidation(Map<String, Object> scanParameters)
-        throws PluginExceptionHandler {
+    public boolean performScanParameterValidation(Map<String, Object> scanParameters) throws PluginExceptionHandler {
         Set<String> securityProducts = getSynopsysSecurityProducts(scanParameters);
 
         if (securityProducts.contains(SecurityProduct.BLACKDUCK.name())) {

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scan/ScanParametersService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scan/ScanParametersService.java
@@ -1,7 +1,9 @@
 package io.jenkins.plugins.synopsys.security.scan.service.scan;
 
 import hudson.model.TaskListener;
+import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
+import io.jenkins.plugins.synopsys.security.scan.global.ErrorCode;
 import io.jenkins.plugins.synopsys.security.scan.global.enums.SecurityProduct;
 import io.jenkins.plugins.synopsys.security.scan.service.scan.blackduck.BlackDuckParametersService;
 import io.jenkins.plugins.synopsys.security.scan.service.scan.coverity.CoverityParametersService;
@@ -18,27 +20,30 @@ public class ScanParametersService {
         this.listener = listener;
     }
 
-    public boolean isValidScanParameters(Map<String, Object> scanParameters) {
+    public boolean performScanParameterValidation(Map<String, Object> scanParameters)
+        throws PluginExceptionHandler {
         Set<String> securityProducts = getSynopsysSecurityProducts(scanParameters);
-
-        boolean isValidBlackDuckParameters = true;
-        boolean isValidCoverityParameters = true;
-        boolean isValidPolarisParameters = true;
 
         if (securityProducts.contains(SecurityProduct.BLACKDUCK.name())) {
             BlackDuckParametersService blackDuckParametersService = new BlackDuckParametersService(listener);
-            isValidBlackDuckParameters = blackDuckParametersService.isValidBlackDuckParameters(scanParameters);
+            if (!blackDuckParametersService.isValidBlackDuckParameters(scanParameters)) {
+                throw new PluginExceptionHandler(ErrorCode.INVALID_BLACKDUCK_PARAMETERS);
+            }
         }
         if (securityProducts.contains(SecurityProduct.COVERITY.name())) {
             CoverityParametersService coverityParametersService = new CoverityParametersService(listener);
-            isValidCoverityParameters = coverityParametersService.isValidCoverityParameters(scanParameters);
+            if (!coverityParametersService.isValidCoverityParameters(scanParameters)) {
+                throw new PluginExceptionHandler(ErrorCode.INVALID_BLACKDUCK_PARAMETERS);
+            }
         }
         if (securityProducts.contains(SecurityProduct.POLARIS.name())) {
             PolarisParametersService polarisParametersService = new PolarisParametersService(listener);
-            isValidPolarisParameters = polarisParametersService.isValidPolarisParameters(scanParameters);
+            if (!polarisParametersService.isValidPolarisParameters(scanParameters)) {
+                throw new PluginExceptionHandler(ErrorCode.INVALID_BLACKDUCK_PARAMETERS);
+            }
         }
 
-        return isValidBlackDuckParameters && isValidCoverityParameters && isValidPolarisParameters;
+        return true;
     }
 
     public Set<String> getSynopsysSecurityProducts(Map<String, Object> scanParameters) {

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scan/ScanParametersService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scan/ScanParametersService.java
@@ -34,7 +34,7 @@ public class ScanParametersService {
         }
         if (securityProducts.contains(SecurityProduct.COVERITY.name())) {
             CoverityParametersService coverityParametersService = new CoverityParametersService(listener, envVars);
-            if (!coverityParametersService.isValidCoverityParameters(scanParameters, envVars)) {
+            if (!coverityParametersService.isValidCoverityParameters(scanParameters)) {
                 throw new PluginExceptionHandler(ErrorCode.INVALID_BLACKDUCK_PARAMETERS);
             }
         }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scan/blackduck/BlackDuckParametersService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scan/blackduck/BlackDuckParametersService.java
@@ -2,11 +2,13 @@ package io.jenkins.plugins.synopsys.security.scan.service.scan.blackduck;
 
 import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
-import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.input.blackduck.BlackDuck;
 import io.jenkins.plugins.synopsys.security.scan.input.blackduck.Download;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 public class BlackDuckParametersService {
     private final LoggerWrapper logger;
@@ -37,7 +39,7 @@ public class BlackDuckParametersService {
             logger.info("BlackDuck parameters are validated successfully");
             return true;
         } else {
-            logger.error(LogMessages.BLACKDUCK_PARAMETER_VALIDATION_FAILED);
+            logger.error("BlackDuck parameters are not valid");
             logger.error("Invalid BlackDuck parameters: " + invalidParams);
             return false;
         }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scan/coverity/CoverityParametersService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scan/coverity/CoverityParametersService.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.synopsys.security.scan.service.scan.coverity;
 
 import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
-import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.input.coverity.Coverity;
 import java.util.ArrayList;
@@ -42,7 +41,7 @@ public class CoverityParametersService {
             logger.info("Coverity parameters are validated successfully");
             return true;
         } else {
-            logger.error(LogMessages.COVERITY_PARAMETER_VALIDATION_FAILED);
+            logger.error("Coverity parameters are not valid");
             logger.error("Invalid Coverity parameters: " + invalidParams);
             return false;
         }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scan/polaris/PolarisParametersService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scan/polaris/PolarisParametersService.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.synopsys.security.scan.service.scan.polaris;
 
 import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
-import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.input.polaris.Polaris;
 import java.util.ArrayList;
@@ -44,7 +43,7 @@ public class PolarisParametersService {
             logger.info("Polaris parameters are validated successfully");
             return true;
         } else {
-            logger.error(LogMessages.POLARIS_PARAMETER_VALIDATION_FAILED);
+            logger.error("Polaris parameters are not valid");
             logger.error("Invalid Polaris parameters: " + invalidParams);
             return false;
         }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/bitbucket/BitbucketRepositoryService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/bitbucket/BitbucketRepositoryService.java
@@ -7,7 +7,6 @@ import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
 import io.jenkins.plugins.synopsys.security.scan.global.ErrorCode;
-import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.global.Utility;
 import io.jenkins.plugins.synopsys.security.scan.input.scm.bitbucket.Bitbucket;
@@ -31,8 +30,8 @@ public class BitbucketRepositoryService {
 
         String bitbucketToken = (String) scanParameters.get(ApplicationConstants.BITBUCKET_TOKEN_KEY);
         if (Utility.isStringNullOrBlank(bitbucketToken) && isFixPrOrPrComment) {
-            logger.error(LogMessages.NO_BITBUCKET_TOKEN_FOUND);
-            throw new PluginExceptionHandler(ErrorCode.SCM_TOKEN_NOT_FOUND, LogMessages.NO_BITBUCKET_TOKEN_FOUND);
+            logger.error("PrComment is set true but no Bitbucket token found!");
+            throw new PluginExceptionHandler(ErrorCode.NO_BITBUCKET_TOKEN_FOUND);
         }
 
         BitbucketApi bitbucketApiFromSCMSource = bitbucketSCMSource.buildBitbucketClient(

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/bitbucket/BitbucketRepositoryService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/bitbucket/BitbucketRepositoryService.java
@@ -6,6 +6,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
+import io.jenkins.plugins.synopsys.security.scan.global.ErrorCode;
 import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.global.Utility;
@@ -31,7 +32,7 @@ public class BitbucketRepositoryService {
         String bitbucketToken = (String) scanParameters.get(ApplicationConstants.BITBUCKET_TOKEN_KEY);
         if (Utility.isStringNullOrBlank(bitbucketToken) && isFixPrOrPrComment) {
             logger.error(LogMessages.NO_BITBUCKET_TOKEN_FOUND);
-            throw new PluginExceptionHandler(LogMessages.NO_BITBUCKET_TOKEN_FOUND);
+            throw new PluginExceptionHandler(ErrorCode.SCM_TOKEN_NOT_FOUND, LogMessages.NO_BITBUCKET_TOKEN_FOUND);
         }
 
         BitbucketApi bitbucketApiFromSCMSource = bitbucketSCMSource.buildBitbucketClient(

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/github/GithubRepositoryService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/github/GithubRepositoryService.java
@@ -4,7 +4,6 @@ import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
 import io.jenkins.plugins.synopsys.security.scan.global.ErrorCode;
-import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.global.Utility;
 import io.jenkins.plugins.synopsys.security.scan.input.scm.github.Github;
@@ -33,8 +32,8 @@ public class GithubRepositoryService {
         String githubToken = (String) scanParameters.get(ApplicationConstants.GITHUB_TOKEN_KEY);
 
         if (isFixPrOrPrComment && Utility.isStringNullOrBlank(githubToken)) {
-            logger.error(LogMessages.NO_GITHUB_TOKEN_FOUND);
-            throw new PluginExceptionHandler(ErrorCode.SCM_TOKEN_NOT_FOUND, LogMessages.NO_GITHUB_TOKEN_FOUND);
+            logger.error("PrComment is set true but no GitHub token found!");
+            throw new PluginExceptionHandler(ErrorCode.NO_GITHUB_TOKEN_FOUND);
         }
 
         Github github = new Github();
@@ -48,7 +47,8 @@ public class GithubRepositoryService {
         String githubHostUrl = extractGitHubHost(githubApiUri);
 
         if (githubHostUrl.equals(INVALID_GITHUB_REPO_URL)) {
-            throw new PluginExceptionHandler(ErrorCode.SCM_URL_VALIDATION_FAILED, INVALID_GITHUB_REPO_URL);
+            logger.error(INVALID_GITHUB_REPO_URL);
+            throw new PluginExceptionHandler(ErrorCode.INVALID_GITHUB_URL);
         } else {
             if (githubHostUrl.startsWith(GITHUB_CLOUD_HOST_URL)) {
                 github.getHost().setUrl("");

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/github/GithubRepositoryService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/github/GithubRepositoryService.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.synopsys.security.scan.service.scm.github;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
+import io.jenkins.plugins.synopsys.security.scan.global.ErrorCode;
 import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.global.Utility;
@@ -33,7 +34,7 @@ public class GithubRepositoryService {
 
         if (isFixPrOrPrComment && Utility.isStringNullOrBlank(githubToken)) {
             logger.error(LogMessages.NO_GITHUB_TOKEN_FOUND);
-            throw new PluginExceptionHandler(LogMessages.NO_GITHUB_TOKEN_FOUND);
+            throw new PluginExceptionHandler(ErrorCode.SCM_TOKEN_NOT_FOUND, LogMessages.NO_GITHUB_TOKEN_FOUND);
         }
 
         Github github = new Github();
@@ -46,7 +47,7 @@ public class GithubRepositoryService {
 
         String githubHostUrl = extractGitHubHost(repositoryUrl);
         if (githubHostUrl.equals(INVALID_GITHUB_REPO_URL)) {
-            throw new PluginExceptionHandler(INVALID_GITHUB_REPO_URL);
+            throw new PluginExceptionHandler(ErrorCode.SCM_URL_VALIDATION_FAILED, INVALID_GITHUB_REPO_URL);
         } else {
             if (githubHostUrl.startsWith(GITHUB_CLOUD_HOST_URL)) {
                 github.getHost().setUrl("");

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/gitlab/GitlabRepositoryService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/gitlab/GitlabRepositoryService.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.synopsys.security.scan.service.scm.gitlab;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
+import io.jenkins.plugins.synopsys.security.scan.global.ErrorCode;
 import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.global.Utility;
@@ -32,7 +33,7 @@ public class GitlabRepositoryService {
 
         if (isFixPrOrPrComment && Utility.isStringNullOrBlank(gitlabToken)) {
             logger.error(LogMessages.NO_GITLAB_TOKEN_FOUND);
-            throw new PluginExceptionHandler(LogMessages.NO_GITLAB_TOKEN_FOUND);
+            throw new PluginExceptionHandler(ErrorCode.SCM_TOKEN_NOT_FOUND, LogMessages.NO_GITLAB_TOKEN_FOUND);
         }
 
         Gitlab gitlab = new Gitlab();
@@ -44,7 +45,7 @@ public class GitlabRepositoryService {
 
         String gitlabHostUrl = extractGitlabHost(repositoryUrl);
         if (gitlabHostUrl.equals(INVALID_GITLAB_REPO_URL)) {
-            throw new PluginExceptionHandler(INVALID_GITLAB_REPO_URL);
+            throw new PluginExceptionHandler(ErrorCode.SCM_URL_VALIDATION_FAILED, INVALID_GITLAB_REPO_URL);
         } else {
             if (gitlabHostUrl.startsWith(GITLAB_CLOUD_HOST_URL)) {
                 gitlab.getApi().setUrl("");

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/gitlab/GitlabRepositoryService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/gitlab/GitlabRepositoryService.java
@@ -4,7 +4,6 @@ import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
 import io.jenkins.plugins.synopsys.security.scan.global.ErrorCode;
-import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.global.Utility;
 import io.jenkins.plugins.synopsys.security.scan.input.scm.gitlab.Gitlab;
@@ -32,8 +31,8 @@ public class GitlabRepositoryService {
         String gitlabToken = (String) scanParameters.get(ApplicationConstants.GITLAB_TOKEN_KEY);
 
         if (isFixPrOrPrComment && Utility.isStringNullOrBlank(gitlabToken)) {
-            logger.error(LogMessages.NO_GITLAB_TOKEN_FOUND);
-            throw new PluginExceptionHandler(ErrorCode.SCM_TOKEN_NOT_FOUND, LogMessages.NO_GITLAB_TOKEN_FOUND);
+            logger.error("PrComment is set true but no GitLab token found!");
+            throw new PluginExceptionHandler(ErrorCode.NO_GITLAB_TOKEN_FOUND);
         }
 
         Gitlab gitlab = new Gitlab();
@@ -46,7 +45,8 @@ public class GitlabRepositoryService {
         String gitlabHostUrl = extractGitlabHost(repositoryUrl);
 
         if (gitlabHostUrl.equals(INVALID_GITLAB_REPO_URL)) {
-            throw new PluginExceptionHandler(ErrorCode.SCM_URL_VALIDATION_FAILED, INVALID_GITLAB_REPO_URL);
+            logger.error(INVALID_GITLAB_REPO_URL);
+            throw new PluginExceptionHandler(ErrorCode.INVALID_GITLAB_URL);
         } else {
             if (gitlabHostUrl.startsWith(GITLAB_CLOUD_HOST_URL)) {
                 gitlab.getApi().setUrl("");

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep/config.jelly
@@ -77,6 +77,9 @@
         <f:entry field="network_airgap" title="Network Airgap (Optional)">
             <f:checkbox/>
         </f:entry>
+        <f:entry field="return_status" title="Return Status Code (Optional)">
+            <f:checkbox/>
+        </f:entry>
     </f:section>
 
     <script type="text/javascript">

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep/help-return_status.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep/help-return_status.html
@@ -1,0 +1,4 @@
+<div>
+    If true (checked), returns the status code of the Synopsys Security Scan instead of failing the workflow.
+    Supported values: <code>true</code> or <code>false</code>
+</div>

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandlerTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandlerTest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.synopsys.security.scan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.TaskListener;

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandlerTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandlerTest.java
@@ -1,14 +1,13 @@
 package io.jenkins.plugins.synopsys.security.scan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.exception.ScannerException;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
+import io.jenkins.plugins.synopsys.security.scan.global.ErrorCode;
 import io.jenkins.plugins.synopsys.security.scan.service.scan.ScanParametersService;
 import java.io.File;
 import java.io.PrintStream;
@@ -50,7 +49,7 @@ public class PluginParametersHandlerTest {
     }
 
     @Test
-    public void initializeScannerInvalidParametersTest() {
+    public void initializeScannerInvalidParametersTest() throws PluginExceptionHandler {
         ScanParametersService mockScanParametersService = Mockito.mock(ScanParametersService.class);
 
         Map<String, Object> scanParameters = new HashMap<>();
@@ -59,11 +58,13 @@ public class PluginParametersHandlerTest {
         Mockito.when(mockScanParametersService.isValidScanParameters(scanParameters))
                 .thenReturn(false);
 
-        assertThrows(PluginExceptionHandler.class, () -> pluginParametersHandler.initializeScanner(scanParameters));
+        int exitCode = pluginParametersHandler.initializeScanner(scanParameters);
+
+        assertEquals(ErrorCode.PARAMETER_VALIDATION_FAILED, exitCode);
     }
 
     @Test
-    public void initializeScannerAirGapFailureTest() {
+    public void initializeScannerAirGapFailureTest() throws PluginExceptionHandler {
         Map<String, Object> scanParameters = new HashMap<>();
         scanParameters.put(ApplicationConstants.PRODUCT_KEY, "BLACKDUCK");
         scanParameters.put(ApplicationConstants.BLACKDUCK_URL_KEY, "https://fake.blackduck.url");
@@ -71,7 +72,9 @@ public class PluginParametersHandlerTest {
         scanParameters.put(ApplicationConstants.NETWORK_AIRGAP_KEY, true);
         scanParameters.put(ApplicationConstants.SYNOPSYS_BRIDGE_INSTALL_DIRECTORY, "/path/to/bridge");
 
-        assertThrows(PluginExceptionHandler.class, () -> pluginParametersHandler.initializeScanner(scanParameters));
+        int exitCode = pluginParametersHandler.initializeScanner(scanParameters);
+
+        assertEquals(ErrorCode.PARAMETER_VALIDATION_FAILED, exitCode);
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandlerTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandlerTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.synopsys.security.scan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.TaskListener;

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandlerTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/PluginParametersHandlerTest.java
@@ -1,15 +1,12 @@
 package io.jenkins.plugins.synopsys.security.scan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
-import io.jenkins.plugins.synopsys.security.scan.exception.ScannerException;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
-import io.jenkins.plugins.synopsys.security.scan.global.ErrorCode;
-import io.jenkins.plugins.synopsys.security.scan.service.scan.ScanParametersService;
 import java.io.File;
 import java.io.PrintStream;
 import java.util.HashMap;
@@ -38,7 +35,7 @@ public class PluginParametersHandlerTest {
     }
 
     @Test
-    public void initializeScannerValidParametersTest() throws PluginExceptionHandler, ScannerException {
+    public void initializeScannerValidParametersTest() throws PluginExceptionHandler {
         Map<String, Object> scanParameters = new HashMap<>();
         scanParameters.put(ApplicationConstants.PRODUCT_KEY, "BLACKDUCK");
         scanParameters.put(ApplicationConstants.BLACKDUCK_URL_KEY, "https://fake.blackduck.url");
@@ -50,22 +47,15 @@ public class PluginParametersHandlerTest {
     }
 
     @Test
-    public void initializeScannerInvalidParametersTest() throws PluginExceptionHandler {
-        ScanParametersService mockScanParametersService = Mockito.mock(ScanParametersService.class);
-
+    public void initializeScannerInvalidParametersTest() {
         Map<String, Object> scanParameters = new HashMap<>();
         scanParameters.put(ApplicationConstants.PRODUCT_KEY, "BLACKDUCK");
 
-        Mockito.when(mockScanParametersService.isValidScanParameters(scanParameters))
-                .thenReturn(false);
-
-        int exitCode = pluginParametersHandler.initializeScanner(scanParameters);
-
-        assertEquals(ErrorCode.PARAMETER_VALIDATION_FAILED, exitCode);
+        assertThrows(PluginExceptionHandler.class, () -> pluginParametersHandler.initializeScanner(scanParameters));
     }
 
     @Test
-    public void initializeScannerAirGapFailureTest() throws PluginExceptionHandler {
+    public void initializeScannerAirGapFailureTest() {
         Map<String, Object> scanParameters = new HashMap<>();
         scanParameters.put(ApplicationConstants.PRODUCT_KEY, "BLACKDUCK");
         scanParameters.put(ApplicationConstants.BLACKDUCK_URL_KEY, "https://fake.blackduck.url");
@@ -73,13 +63,11 @@ public class PluginParametersHandlerTest {
         scanParameters.put(ApplicationConstants.NETWORK_AIRGAP_KEY, true);
         scanParameters.put(ApplicationConstants.SYNOPSYS_BRIDGE_INSTALL_DIRECTORY, "/path/to/bridge");
 
-        int exitCode = pluginParametersHandler.initializeScanner(scanParameters);
-
-        assertEquals(ErrorCode.PARAMETER_VALIDATION_FAILED, exitCode);
+        assertThrows(PluginExceptionHandler.class, () -> pluginParametersHandler.initializeScanner(scanParameters));
     }
 
     @Test
-    public void initializeScannerAirGapSuccessTest() throws PluginExceptionHandler, ScannerException {
+    public void initializeScannerAirGapSuccessTest() throws PluginExceptionHandler {
         Map<String, Object> scanParameters = new HashMap<>();
         scanParameters.put(ApplicationConstants.PRODUCT_KEY, "BLACKDUCK");
         scanParameters.put(ApplicationConstants.BLACKDUCK_URL_KEY, "https://fake.blackduck.url");

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeInstallTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/bridge/BridgeInstallTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.FilePath;
 import hudson.model.TaskListener;
+import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -46,7 +47,7 @@ public class BridgeInstallTest {
             assertTrue(bridgeInstallationPath.child("demo-bridge-LICENSE.txt").exists());
 
             cleanupBridgeInstallationPath(bridgeInstallationPath);
-        } catch (IOException | InterruptedException e) {
+        } catch (IOException | InterruptedException | PluginExceptionHandler e) {
             System.out.println("Exception occurred during testing for installSynopsysBridge method. " + e.getMessage());
         }
     }

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParameterServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParameterServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.bridge.BridgeDownloadParameters;
@@ -44,8 +45,10 @@ public class BridgeDownloadParameterServiceTest {
         BridgeDownloadParameters bridgeDownloadParameters = new BridgeDownloadParameters(workspace, listenerMock);
         bridgeDownloadParameters.setBridgeDownloadVersion("x.x.x");
 
-        assertThrows(PluginExceptionHandler.class,
-            () -> bridgeDownloadParametersService.performBridgeDownloadParameterValidation(bridgeDownloadParameters));
+        assertThrows(
+                PluginExceptionHandler.class,
+                () -> bridgeDownloadParametersService.performBridgeDownloadParameterValidation(
+                        bridgeDownloadParameters));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParameterServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParameterServiceTest.java
@@ -3,11 +3,12 @@ package io.jenkins.plugins.synopsys.security.scan.service.bridge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.bridge.BridgeDownloadParameters;
+import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
 import java.io.File;
 import java.io.PrintStream;
@@ -27,6 +28,24 @@ public class BridgeDownloadParameterServiceTest {
         workspace = new FilePath(new File(getHomeDirectory()));
         Mockito.when(listenerMock.getLogger()).thenReturn(Mockito.mock(PrintStream.class));
         bridgeDownloadParametersService = new BridgeDownloadParametersService(workspace, listenerMock);
+    }
+
+    @Test
+    void performBridgeDownloadParameterValidationSuccessTest() throws PluginExceptionHandler {
+        BridgeDownloadParameters bridgeDownloadParameters = new BridgeDownloadParameters(workspace, listenerMock);
+        bridgeDownloadParameters.setBridgeDownloadUrl("https://fake.url.com");
+        bridgeDownloadParameters.setBridgeDownloadVersion("1.2.3");
+
+        assertTrue(bridgeDownloadParametersService.performBridgeDownloadParameterValidation(bridgeDownloadParameters));
+    }
+
+    @Test
+    void performBridgeDownloadParameterValidationFailureTest() {
+        BridgeDownloadParameters bridgeDownloadParameters = new BridgeDownloadParameters(workspace, listenerMock);
+        bridgeDownloadParameters.setBridgeDownloadVersion("x.x.x");
+
+        assertThrows(PluginExceptionHandler.class,
+            () -> bridgeDownloadParametersService.performBridgeDownloadParameterValidation(bridgeDownloadParameters));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/scan/ScanParametersServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/scan/ScanParametersServiceTest.java
@@ -40,8 +40,8 @@ public class ScanParametersServiceTest {
         parameters.put(ApplicationConstants.BLACKDUCK_URL_KEY, "https://fake.blackduck.url");
         parameters.put(ApplicationConstants.BLACKDUCK_TOKEN_KEY, "MDJDSROSVC56FAKEKEY");
 
-        assertThrows(PluginExceptionHandler.class,
-            () -> scanParametersService.performScanParameterValidation(parameters));
+        assertThrows(
+                PluginExceptionHandler.class, () -> scanParametersService.performScanParameterValidation(parameters));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/scan/ScanParametersServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/scan/ScanParametersServiceTest.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.synopsys.security.scan.service.scan;
 import static org.junit.jupiter.api.Assertions.*;
 
 import hudson.model.TaskListener;
+import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
 import java.io.PrintStream;
 import java.util.HashMap;
@@ -23,27 +24,28 @@ public class ScanParametersServiceTest {
     }
 
     @Test
-    void validParametersForBlackDuckTest() {
+    void performScanParameterValidationSuccessForBlackDuckTest() throws PluginExceptionHandler {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put(ApplicationConstants.PRODUCT_KEY, "blackduck");
         parameters.put(ApplicationConstants.BLACKDUCK_URL_KEY, "https://fake.blackduck.url");
         parameters.put(ApplicationConstants.BLACKDUCK_TOKEN_KEY, "MDJDSROSVC56FAKEKEY");
 
-        assertTrue(scanParametersService.isValidScanParameters(parameters));
+        assertTrue(scanParametersService.performScanParameterValidation(parameters));
     }
 
     @Test
-    void invalidParametersForBlackDuckAndPolarisTest() {
+    void performScanParameterValidationFailureForBlackDuckAndPolarisTest() {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put(ApplicationConstants.PRODUCT_KEY, "blackduck, polaris");
         parameters.put(ApplicationConstants.BLACKDUCK_URL_KEY, "https://fake.blackduck.url");
         parameters.put(ApplicationConstants.BLACKDUCK_TOKEN_KEY, "MDJDSROSVC56FAKEKEY");
 
-        assertFalse(scanParametersService.isValidScanParameters(parameters));
+        assertThrows(PluginExceptionHandler.class,
+            () -> scanParametersService.performScanParameterValidation(parameters));
     }
 
     @Test
-    void validParametersForBlackDuckAndPolarisTest() {
+    void performScanParameterValidationSuccessForBlackDuckAndPolarisTest() throws PluginExceptionHandler {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put(ApplicationConstants.PRODUCT_KEY, "blackduck, polaris");
 
@@ -57,7 +59,7 @@ public class ScanParametersServiceTest {
         parameters.put(ApplicationConstants.POLARIS_ASSESSMENT_TYPES_KEY, "SCA, SAST");
         parameters.put(ApplicationConstants.POLARIS_BRANCH_NAME_KEY, "test-branch");
 
-        assertTrue(scanParametersService.isValidScanParameters(parameters));
+        assertTrue(scanParametersService.performScanParameterValidation(parameters));
     }
 
     @Test


### PR DESCRIPTION
- added new parameter `return_status` in scan step
- added new input field (`return_status`) in pipeline syntax
- introduced error codes for bridge specific errors and plugin specific errors 
- refactored exception throwing logic based on `return_status` 
- modified unit tests