### PR TITLE
Scripted Pipeline bug fix for gitlab and github

### DIFF
--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/SCMRepositoryService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/SCMRepositoryService.java
@@ -42,8 +42,8 @@ public class SCMRepositoryService {
 
             String repositoryOwner = gitHubSCMSource.getRepoOwner();
             String repositoryName = gitHubSCMSource.getRepository();
+            String repositoryUrl = gitHubSCMSource.getRepositoryUrl();
             String branchName = envVars.get(ApplicationConstants.BRANCH_NAME);
-            String repositoryUrl = envVars.get(ApplicationConstants.GIT_URL);
 
             return githubRepositoryService.createGithubObject(
                     scanParameters,
@@ -57,7 +57,7 @@ public class SCMRepositoryService {
             GitlabRepositoryService gitlabRepositoryService = new GitlabRepositoryService(listener);
             GitLabSCMSource gitLabSCMSource = (GitLabSCMSource) scmSource;
 
-            String repositoryUrl = envVars.get(ApplicationConstants.GIT_URL);
+            String repositoryUrl = gitLabSCMSource.getHttpRemote();
             String branchName = envVars.get(ApplicationConstants.BRANCH_NAME);
             String repositoryName = gitLabSCMSource.getProjectPath();
 


### PR DESCRIPTION
-  While using scripted pipeline syntax,  We were getting the null value for Repository URL for github and gitlab scm. In this PR we fixed that.