### PR TITLE
Scripted Pipeline bug fix for gitlab.

### DIFF
--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/SCMRepositoryService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/SCMRepositoryService.java
@@ -57,7 +57,7 @@ public class SCMRepositoryService {
             GitlabRepositoryService gitlabRepositoryService = new GitlabRepositoryService(listener);
             GitLabSCMSource gitLabSCMSource = (GitLabSCMSource) scmSource;
 
-            String repositoryUrl = envVars.get(ApplicationConstants.GIT_URL);
+            String repositoryUrl = gitLabSCMSource.getHttpRemote();
             String branchName = envVars.get(ApplicationConstants.BRANCH_NAME);
             String repositoryName = gitLabSCMSource.getProjectPath();
 


### PR DESCRIPTION
- While using scripted pipeline syntax, We were getting the null value for Repository URL for the gitlab scm. In this PR we fixed that.