### PR TITLE
SIGINT-1536: Add SARIF parameters for BlackDuck in freestyle UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </scm>
   <properties>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <revision>1.1.0</revision>
+    <revision>1.2.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.401.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -66,10 +66,18 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>gitlab-branch-source</artifactId>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.jettison</groupId>
+          <artifactId>jettison</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-bitbucket-branch-source</artifactId>
+      <optional>true</optional>
       <exclusions>
         <exclusion>
           <groupId>org.yaml</groupId>
@@ -80,6 +88,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-branch-source</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/SecurityScanner.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/SecurityScanner.java
@@ -10,6 +10,7 @@ import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandle
 import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
 import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
+import io.jenkins.plugins.synopsys.security.scan.global.Utility;
 import io.jenkins.plugins.synopsys.security.scan.global.enums.ReportType;
 import io.jenkins.plugins.synopsys.security.scan.global.enums.SecurityProduct;
 import io.jenkins.plugins.synopsys.security.scan.service.ScannerArgumentService;
@@ -51,7 +52,8 @@ public class SecurityScanner {
             throws PluginExceptionHandler {
         int scanner = -1;
 
-        List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(scanParams, bridgeInstallationPath);
+        List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(
+                Utility.installedBranchSourceDependcies(), scanParams, bridgeInstallationPath);
 
         logger.info("Executable command line arguments: "
                 + commandLineArgs.stream()

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/SecurityScan.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/SecurityScan.java
@@ -76,5 +76,4 @@ public interface SecurityScan {
     public Boolean isBlackduck_reports_sarif_groupSCAIssues();
 
     public String getBlackduck_reports_sarif_severities();
-
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/SecurityScan.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/SecurityScan.java
@@ -1,0 +1,80 @@
+package io.jenkins.plugins.synopsys.security.scan.extension;
+
+public interface SecurityScan {
+    public String getProduct();
+
+    public String getBlackduck_url();
+
+    public String getBlackduck_token();
+
+    public String getBlackduck_install_directory();
+
+    public Boolean isBlackduck_scan_full();
+
+    public Boolean isBlackduckIntelligentScan();
+
+    public String getBlackduck_scan_failure_severities();
+
+    public Boolean isBlackduck_automation_prcomment();
+
+    public String getBlackduck_download_url();
+
+    public String getCoverity_url();
+
+    public String getCoverity_user();
+
+    public String getCoverity_passphrase();
+
+    public String getCoverity_project_name();
+
+    public String getCoverity_stream_name();
+
+    public String getCoverity_policy_view();
+
+    public String getCoverity_install_directory();
+
+    public Boolean isCoverity_automation_prcomment();
+
+    public String getCoverity_version();
+
+    public Boolean isCoverity_local();
+
+    public String getPolaris_server_url();
+
+    public String getPolaris_access_token();
+
+    public String getPolaris_application_name();
+
+    public String getPolaris_project_name();
+
+    public String getPolaris_assessment_types();
+
+    public String getPolaris_triage();
+
+    public String getPolaris_branch_name();
+
+    public String getBitbucket_token();
+
+    public String getGithub_token();
+
+    public String getGitlab_token();
+
+    public String getSynopsys_bridge_download_url();
+
+    public String getSynopsys_bridge_download_version();
+
+    public String getSynopsys_bridge_install_directory();
+
+    public Boolean isInclude_diagnostics();
+
+    public Boolean isNetwork_airgap();
+
+    public Boolean isBlackduck_reports_sarif_create();
+
+    public String getBlackduck_reports_sarif_file_path();
+
+    public Boolean isBlackduck_reports_sarif_groupSCAIssues();
+
+    public String getBlackduck_reports_sarif_severities();
+
+}

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle.java
@@ -1,39 +1,28 @@
-package io.jenkins.plugins.synopsys.security.scan.extension.pipeline;
+package io.jenkins.plugins.synopsys.security.scan.extension.freestyle;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.*;
-import hudson.model.Node;
-import hudson.model.Run;
-import hudson.model.TaskListener;
+import hudson.model.*;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
 import hudson.util.ListBoxModel;
-import hudson.util.ListBoxModel.Option;
 import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
 import io.jenkins.plugins.synopsys.security.scan.exception.ScannerException;
 import io.jenkins.plugins.synopsys.security.scan.extension.SecurityScan;
 import io.jenkins.plugins.synopsys.security.scan.factory.ScanParametersFactory;
-import io.jenkins.plugins.synopsys.security.scan.global.ApplicationConstants;
 import io.jenkins.plugins.synopsys.security.scan.global.ExceptionMessages;
-import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.global.enums.SecurityProduct;
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.*;
-import javax.annotation.Nonnull;
-import org.jenkinsci.plugins.workflow.steps.Step;
-import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
-import org.jenkinsci.plugins.workflow.steps.StepExecution;
-import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import java.util.Map;
+import jenkins.tasks.SimpleBuildStep;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-public class SecurityScanStep extends Step implements SecurityScan, Serializable {
-    private static final long serialVersionUID = 6294070801130995534L;
-
+public class SecurityScanFreestyle extends Builder implements SecurityScan, SimpleBuildStep {
     private String product;
-
     private String blackduck_url;
     private transient String blackduck_token;
+    private transient String github_token;
+    private transient String gitlab_token;
     private String blackduck_install_directory;
     private Boolean blackduck_scan_full;
     private Boolean blackduckIntelligentScan;
@@ -41,6 +30,10 @@ public class SecurityScanStep extends Step implements SecurityScan, Serializable
     //    private Boolean blackduck_automation_fixpr;
     private Boolean blackduck_automation_prcomment;
     private String blackduck_download_url;
+    private Boolean blackduck_reports_sarif_create;
+    private String blackduck_reports_sarif_file_path;
+    private Boolean blackduck_reports_sarif_groupSCAIssues;
+    private String blackduck_reports_sarif_severities;
 
     private String coverity_url;
     private String coverity_user;
@@ -63,21 +56,15 @@ public class SecurityScanStep extends Step implements SecurityScan, Serializable
     //    private String polaris_branch_parent_name;
 
     private transient String bitbucket_token;
-    private transient String github_token;
-    private transient String gitlab_token;
 
     private String synopsys_bridge_download_url;
     private String synopsys_bridge_download_version;
     private String synopsys_bridge_install_directory;
     private Boolean include_diagnostics;
     private Boolean network_airgap;
-    private Boolean blackduck_reports_sarif_create;
-    private String blackduck_reports_sarif_file_path;
-    private Boolean blackduck_reports_sarif_groupSCAIssues;
-    private String blackduck_reports_sarif_severities;
 
     @DataBoundConstructor
-    public SecurityScanStep() {
+    public SecurityScanFreestyle() {
         // this block is kept empty intentionally
     }
 
@@ -115,6 +102,22 @@ public class SecurityScanStep extends Step implements SecurityScan, Serializable
 
     public String getBlackduck_download_url() {
         return blackduck_download_url;
+    }
+
+    public Boolean isBlackduck_reports_sarif_create() {
+        return blackduck_reports_sarif_create;
+    }
+
+    public String getBlackduck_reports_sarif_file_path() {
+        return blackduck_reports_sarif_file_path;
+    }
+
+    public Boolean isBlackduck_reports_sarif_groupSCAIssues() {
+        return blackduck_reports_sarif_groupSCAIssues;
+    }
+
+    public String getBlackduck_reports_sarif_severities() {
+        return blackduck_reports_sarif_severities;
     }
 
     public String getCoverity_url() {
@@ -217,22 +220,6 @@ public class SecurityScanStep extends Step implements SecurityScan, Serializable
         return network_airgap;
     }
 
-    public Boolean isBlackduck_reports_sarif_create() {
-        return blackduck_reports_sarif_create;
-    }
-
-    public String getBlackduck_reports_sarif_file_path() {
-        return blackduck_reports_sarif_file_path;
-    }
-
-    public Boolean isBlackduck_reports_sarif_groupSCAIssues() {
-        return blackduck_reports_sarif_groupSCAIssues;
-    }
-
-    public String getBlackduck_reports_sarif_severities() {
-        return blackduck_reports_sarif_severities;
-    }
-
     @DataBoundSetter
     public void setProduct(String product) {
         this.product = product;
@@ -277,6 +264,26 @@ public class SecurityScanStep extends Step implements SecurityScan, Serializable
     @DataBoundSetter
     public void setBlackduck_download_url(String blackduck_download_url) {
         this.blackduck_download_url = Util.fixEmptyAndTrim(blackduck_download_url);
+    }
+
+    @DataBoundSetter
+    public void setBlackduck_reports_sarif_create(Boolean blackduck_reports_sarif_create) {
+        this.blackduck_reports_sarif_create = blackduck_reports_sarif_create ? true : null;
+    }
+
+    @DataBoundSetter
+    public void setBlackduck_reports_sarif_file_path(String blackduck_reports_sarif_file_path) {
+        this.blackduck_reports_sarif_file_path = Util.fixEmptyAndTrim(blackduck_reports_sarif_file_path);
+    }
+
+    @DataBoundSetter
+    public void setBlackduck_reports_sarif_groupSCAIssues(Boolean blackduck_reports_sarif_groupSCAIssues) {
+        this.blackduck_reports_sarif_groupSCAIssues = blackduck_reports_sarif_groupSCAIssues ? true : null;
+    }
+
+    @DataBoundSetter
+    public void setBlackduck_reports_sarif_severities(String blackduck_reports_sarif_severities) {
+        this.blackduck_reports_sarif_severities = Util.fixEmptyAndTrim(blackduck_reports_sarif_severities);
     }
 
     @DataBoundSetter
@@ -404,26 +411,6 @@ public class SecurityScanStep extends Step implements SecurityScan, Serializable
         this.network_airgap = network_airgap ? true : null;
     }
 
-    @DataBoundSetter
-    public void setBlackduck_reports_sarif_create(Boolean blackduck_reports_sarif_create) {
-        this.blackduck_reports_sarif_create = blackduck_reports_sarif_create ? true : null;
-    }
-
-    @DataBoundSetter
-    public void setBlackduck_reports_sarif_file_path(String blackduck_reports_sarif_file_path) {
-        this.blackduck_reports_sarif_file_path = Util.fixEmptyAndTrim(blackduck_reports_sarif_file_path);
-    }
-
-    @DataBoundSetter
-    public void setBlackduck_reports_sarif_groupSCAIssues(Boolean blackduck_reports_sarif_groupSCAIssues) {
-        this.blackduck_reports_sarif_groupSCAIssues = blackduck_reports_sarif_groupSCAIssues ? true : null;
-    }
-
-    @DataBoundSetter
-    public void setBlackduck_reports_sarif_severities(String blackduck_reports_sarif_severities) {
-        this.blackduck_reports_sarif_severities = Util.fixEmptyAndTrim(blackduck_reports_sarif_severities);
-    }
-
     private Map<String, Object> getParametersMap(FilePath workspace, TaskListener listener)
             throws PluginExceptionHandler {
         return ScanParametersFactory.preparePipelineParametersMap(
@@ -431,96 +418,60 @@ public class SecurityScanStep extends Step implements SecurityScan, Serializable
     }
 
     @Override
-    public StepExecution start(StepContext context) throws Exception {
-        return new Execution(context);
+    public void perform(
+            @NonNull Run<?, ?> run,
+            @NonNull FilePath workspace,
+            @NonNull EnvVars env,
+            @NonNull Launcher launcher,
+            @NonNull TaskListener listener) {
+
+        listener.getLogger()
+                .println(
+                        "**************************** START EXECUTION OF SYNOPSYS SECURITY SCAN ****************************");
+
+        try {
+            ScanParametersFactory.createPipelineCommand(run, listener, env, launcher, null, workspace)
+                    .initializeScanner(getParametersMap(workspace, listener));
+        } catch (Exception e) {
+
+            if (e instanceof PluginExceptionHandler) {
+                throw new RuntimeException(new PluginExceptionHandler("Workflow failed! " + e.getMessage()));
+            } else {
+                throw new RuntimeException(
+                        new ScannerException(ExceptionMessages.scannerFailureMessage(e.getMessage())));
+            }
+
+        } finally {
+            listener.getLogger()
+                    .println(
+                            "**************************** END EXECUTION OF SYNOPSYS SECURITY SCAN ****************************");
+        }
     }
 
-    @Extension(optional = true)
-    public static final class DescriptorImpl extends StepDescriptor {
-        @Override
-        public Set<? extends Class<?>> getRequiredContext() {
-            return new HashSet<>(Arrays.asList(
-                    Run.class, TaskListener.class, EnvVars.class, FilePath.class, Launcher.class, Node.class));
-        }
+    @Extension
+    public static class Descriptor extends BuildStepDescriptor<Builder> {
 
-        @Override
-        public String getFunctionName() {
-            return ApplicationConstants.PIPELINE_NAME;
-        }
-
-        @Nonnull
         @Override
         public String getDisplayName() {
-            return ApplicationConstants.DISPLAY_NAME;
+            return "Synopsys Security Scan";
+        }
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return jobType.isAssignableFrom(FreeStyleProject.class);
         }
 
         @SuppressWarnings({"lgtm[jenkins/no-permission-check]", "lgtm[jenkins/csrf]"})
         public ListBoxModel doFillProductItems() {
             ListBoxModel items = new ListBoxModel();
-            Map<String, String> customLabels = new HashMap<>();
-
-            items.add(new Option("Select", ""));
-            customLabels.put(SecurityProduct.BLACKDUCK.name().toLowerCase(), "Black Duck");
-            customLabels.put(SecurityProduct.COVERITY.name().toLowerCase(), "Coverity");
-            customLabels.put(SecurityProduct.POLARIS.name().toLowerCase(), "Polaris");
+            items.add(new ListBoxModel.Option("Select", "select"));
 
             for (SecurityProduct product : SecurityProduct.values()) {
+                String label = product.getProductLabel();
                 String value = product.name().toLowerCase();
-                String label = customLabels.getOrDefault(value, product.name());
-                items.add(new Option(label, value));
+                items.add(new ListBoxModel.Option(label, value));
             }
             return items;
-        }
-    }
-
-    public class Execution extends SynchronousNonBlockingStepExecution<Integer> {
-        private static final long serialVersionUID = -2514079516220990421L;
-        private final transient Run<?, ?> run;
-        private final transient Launcher launcher;
-        private final transient Node node;
-
-        @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-        private final transient TaskListener listener;
-
-        @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-        private final transient EnvVars envVars;
-
-        @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
-        private final transient FilePath workspace;
-
-        protected Execution(@Nonnull StepContext context) throws InterruptedException, IOException {
-            super(context);
-            run = context.get(Run.class);
-            listener = context.get(TaskListener.class);
-            envVars = context.get(EnvVars.class);
-            workspace = context.get(FilePath.class);
-            launcher = context.get(Launcher.class);
-            node = context.get(Node.class);
-        }
-
-        @Override
-        protected Integer run() throws PluginExceptionHandler, ScannerException {
-            LoggerWrapper logger = new LoggerWrapper(listener);
-            int result;
-
-            logger.println(
-                    "**************************** START EXECUTION OF SYNOPSYS SECURITY SCAN ****************************");
-
-            try {
-                result = ScanParametersFactory.createPipelineCommand(run, listener, envVars, launcher, node, workspace)
-                        .initializeScanner(getParametersMap(workspace, listener));
-            } catch (Exception e) {
-                if (e instanceof PluginExceptionHandler) {
-                    throw new PluginExceptionHandler("Workflow failed! " + e.getMessage());
-                } else {
-                    throw new ScannerException(ExceptionMessages.scannerFailureMessage(e.getMessage()));
-                }
-            } finally {
-                logger.println(
-                        "**************************** END EXECUTION OF SYNOPSYS SECURITY SCAN ****************************");
-            }
-
-            return result;
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/global/ScannerGlobalConfig.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/global/ScannerGlobalConfig.java
@@ -26,6 +26,8 @@ import org.kohsuke.stapler.verb.POST;
 public class ScannerGlobalConfig extends GlobalConfiguration implements Serializable {
     private static final long serialVersionUID = -3129542889827231427L;
     private final int CONNECTION_TIMEOUT_IN_SECONDS = 120;
+    private String AUTHORIZATION_FAILURE = "Could not perform the authorization request: ";
+    private String CONNECTION_SUCCESSFUL = "Connection successful.";
 
     private String blackDuckUrl;
 
@@ -294,11 +296,10 @@ public class ScannerGlobalConfig extends GlobalConfiguration implements Serializ
                 return FormValidation.error(String.join(" ", validationMessage));
             }
         } catch (Exception e) {
-            return FormValidation.error("Could not perform the authorization request: "
-                    + e.getCause().getMessage());
+            return FormValidation.error(AUTHORIZATION_FAILURE + e.getCause().getMessage());
         }
 
-        return FormValidation.ok("Connection successful.");
+        return FormValidation.ok(CONNECTION_SUCCESSFUL);
     }
 
     private String getValidationMessage(int statusCode) {
@@ -341,11 +342,10 @@ public class ScannerGlobalConfig extends GlobalConfiguration implements Serializ
                 return FormValidation.error(String.join(" ", validationMessage));
             }
         } catch (Exception e) {
-            return FormValidation.error("Could not perform the authorization request: "
-                    + e.getCause().getMessage());
+            return FormValidation.error(AUTHORIZATION_FAILURE + e.getCause().getMessage());
         }
 
-        return FormValidation.ok("Connection successful.");
+        return FormValidation.ok(CONNECTION_SUCCESSFUL);
     }
 
     @POST
@@ -377,10 +377,10 @@ public class ScannerGlobalConfig extends GlobalConfiguration implements Serializ
                 return FormValidation.error(String.join(" ", validationMessage));
             }
         } catch (Exception e) {
-            return FormValidation.error("Could not perform the authorization request: "
-                    + e.getCause().getCause().getMessage());
+            return FormValidation.error(
+                    AUTHORIZATION_FAILURE + e.getCause().getCause().getMessage());
         }
 
-        return FormValidation.ok("Connection successful.");
+        return FormValidation.ok(CONNECTION_SUCCESSFUL);
     }
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactory.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactory.java
@@ -10,8 +10,8 @@ import hudson.model.TaskListener;
 import io.jenkins.plugins.synopsys.security.scan.PluginParametersHandler;
 import io.jenkins.plugins.synopsys.security.scan.SecurityScanner;
 import io.jenkins.plugins.synopsys.security.scan.exception.PluginExceptionHandler;
+import io.jenkins.plugins.synopsys.security.scan.extension.SecurityScan;
 import io.jenkins.plugins.synopsys.security.scan.extension.global.ScannerGlobalConfig;
-import io.jenkins.plugins.synopsys.security.scan.extension.pipeline.SecurityScanStep;
 import io.jenkins.plugins.synopsys.security.scan.global.*;
 import io.jenkins.plugins.synopsys.security.scan.global.ScanCredentialsHelper;
 import io.jenkins.plugins.synopsys.security.scan.global.enums.SecurityProduct;
@@ -50,31 +50,32 @@ public class ScanParametersFactory {
     }
 
     public static Map<String, Object> preparePipelineParametersMap(
-            SecurityScanStep scanStep, Map<String, Object> parametersMap, TaskListener listener)
+            SecurityScan securityScan, Map<String, Object> parametersMap, TaskListener listener)
             throws PluginExceptionHandler {
-        String product = scanStep.getProduct();
+        String product = securityScan.getProduct();
 
         if (validateProduct(product, listener)) {
             parametersMap.put(
                     ApplicationConstants.PRODUCT_KEY,
-                    scanStep.getProduct().trim().toUpperCase());
+                    securityScan.getProduct().trim().toUpperCase());
 
-            parametersMap.putAll(prepareCoverityParametersMap(scanStep));
-            parametersMap.putAll(preparePolarisParametersMap(scanStep));
-            parametersMap.putAll(prepareBlackDuckParametersMap(scanStep));
-            parametersMap.putAll(prepareSarifReportParametersMap(scanStep));
+            parametersMap.putAll(prepareCoverityParametersMap(securityScan));
+            parametersMap.putAll(preparePolarisParametersMap(securityScan));
+            parametersMap.putAll(prepareBlackDuckParametersMap(securityScan));
+            parametersMap.putAll(prepareSarifReportParametersMap(securityScan));
 
-            if (!Utility.isStringNullOrBlank(scanStep.getBitbucket_token())) {
-                parametersMap.put(ApplicationConstants.BITBUCKET_TOKEN_KEY, scanStep.getBitbucket_token());
+            if (!Utility.isStringNullOrBlank(securityScan.getBitbucket_token())) {
+                parametersMap.put(ApplicationConstants.BITBUCKET_TOKEN_KEY, securityScan.getBitbucket_token());
             }
-            if (!Utility.isStringNullOrBlank(scanStep.getGithub_token())) {
-                parametersMap.put(ApplicationConstants.GITHUB_TOKEN_KEY, scanStep.getGithub_token());
-            }
-            if (!Utility.isStringNullOrBlank(scanStep.getGitlab_token())) {
-                parametersMap.put(ApplicationConstants.GITLAB_TOKEN_KEY, scanStep.getGitlab_token());
+            if (!Utility.isStringNullOrBlank(securityScan.getGitlab_token())) {
+                parametersMap.put(ApplicationConstants.GITLAB_TOKEN_KEY, securityScan.getGitlab_token());
             }
 
-            parametersMap.putAll(prepareBridgeParametersMap(scanStep));
+            if (!Utility.isStringNullOrBlank(securityScan.getGithub_token())) {
+                parametersMap.put(ApplicationConstants.GITHUB_TOKEN_KEY, securityScan.getGithub_token());
+            }
+
+            parametersMap.putAll(prepareBridgeParametersMap(securityScan));
 
             return parametersMap;
         } else {
@@ -172,197 +173,205 @@ public class ScanParametersFactory {
         }
     }
 
-    public static Map<String, Object> prepareBlackDuckParametersMap(SecurityScanStep scanStep) {
+    public static Map<String, Object> prepareBlackDuckParametersMap(SecurityScan securityScan) {
         Map<String, Object> blackDuckParameters = new HashMap<>();
 
-        if (!Utility.isStringNullOrBlank(scanStep.getBlackduck_url())) {
-            blackDuckParameters.put(ApplicationConstants.BLACKDUCK_URL_KEY, scanStep.getBlackduck_url());
+        if (!Utility.isStringNullOrBlank(securityScan.getBlackduck_url())) {
+            blackDuckParameters.put(ApplicationConstants.BLACKDUCK_URL_KEY, securityScan.getBlackduck_url());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getBlackduck_token())) {
-            blackDuckParameters.put(ApplicationConstants.BLACKDUCK_TOKEN_KEY, scanStep.getBlackduck_token());
+        if (!Utility.isStringNullOrBlank(securityScan.getBlackduck_token())) {
+            blackDuckParameters.put(ApplicationConstants.BLACKDUCK_TOKEN_KEY, securityScan.getBlackduck_token());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getBlackduck_install_directory())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getBlackduck_install_directory())) {
             blackDuckParameters.put(
-                    ApplicationConstants.BLACKDUCK_INSTALL_DIRECTORY_KEY, scanStep.getBlackduck_install_directory());
+                    ApplicationConstants.BLACKDUCK_INSTALL_DIRECTORY_KEY,
+                    securityScan.getBlackduck_install_directory());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getBlackduck_scan_failure_severities())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getBlackduck_scan_failure_severities())) {
             blackDuckParameters.put(
                     ApplicationConstants.BLACKDUCK_SCAN_FAILURE_SEVERITIES_KEY,
-                    scanStep.getBlackduck_scan_failure_severities().toUpperCase());
+                    securityScan.getBlackduck_scan_failure_severities().toUpperCase());
         }
 
-        if (scanStep.isBlackduckIntelligentScan() != null) {
+        if (securityScan.isBlackduckIntelligentScan() != null) {
             blackDuckParameters.put(
-                    ApplicationConstants.BLACKDUCK_SCAN_FULL_KEY, scanStep.isBlackduckIntelligentScan());
+                    ApplicationConstants.BLACKDUCK_SCAN_FULL_KEY, securityScan.isBlackduckIntelligentScan());
         }
 
-        //        if (scanStep.isBlackduck_automation_fixpr() != null) {
+        //        if (securityScan.isBlackduck_automation_fixpr() != null) {
         //            blackDuckParameters.put(ApplicationConstants.BLACKDUCK_AUTOMATION_FIXPR_KEY,
-        // scanStep.isBlackduck_automation_fixpr());
+        // securityScan.isBlackduck_automation_fixpr());
         //        }
 
-        if (scanStep.isBlackduck_automation_prcomment() != null) {
+        if (securityScan.isBlackduck_automation_prcomment() != null) {
             blackDuckParameters.put(
                     ApplicationConstants.BLACKDUCK_AUTOMATION_PRCOMMENT_KEY,
-                    scanStep.isBlackduck_automation_prcomment());
+                    securityScan.isBlackduck_automation_prcomment());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getBlackduck_download_url())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getBlackduck_download_url())) {
             blackDuckParameters.put(
-                    ApplicationConstants.BLACKDUCK_DOWNLOAD_URL_KEY, scanStep.getBlackduck_download_url());
+                    ApplicationConstants.BLACKDUCK_DOWNLOAD_URL_KEY, securityScan.getBlackduck_download_url());
         }
 
         return blackDuckParameters;
     }
 
-    public static Map<String, Object> prepareCoverityParametersMap(SecurityScanStep scanStep) {
+    public static Map<String, Object> prepareCoverityParametersMap(SecurityScan securityScan) {
         Map<String, Object> coverityParameters = new HashMap<>();
 
-        if (!Utility.isStringNullOrBlank(scanStep.getCoverity_url())) {
-            coverityParameters.put(ApplicationConstants.COVERITY_URL_KEY, scanStep.getCoverity_url());
+        if (!Utility.isStringNullOrBlank(securityScan.getCoverity_url())) {
+            coverityParameters.put(ApplicationConstants.COVERITY_URL_KEY, securityScan.getCoverity_url());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getCoverity_user())) {
-            coverityParameters.put(ApplicationConstants.COVERITY_USER_KEY, scanStep.getCoverity_user());
+        if (!Utility.isStringNullOrBlank(securityScan.getCoverity_user())) {
+            coverityParameters.put(ApplicationConstants.COVERITY_USER_KEY, securityScan.getCoverity_user());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getCoverity_passphrase())) {
-            coverityParameters.put(ApplicationConstants.COVERITY_PASSPHRASE_KEY, scanStep.getCoverity_passphrase());
+        if (!Utility.isStringNullOrBlank(securityScan.getCoverity_passphrase())) {
+            coverityParameters.put(ApplicationConstants.COVERITY_PASSPHRASE_KEY, securityScan.getCoverity_passphrase());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getCoverity_project_name())) {
-            coverityParameters.put(ApplicationConstants.COVERITY_PROJECT_NAME_KEY, scanStep.getCoverity_project_name());
-        }
-
-        if (!Utility.isStringNullOrBlank(scanStep.getCoverity_stream_name())) {
-            coverityParameters.put(ApplicationConstants.COVERITY_STREAM_NAME_KEY, scanStep.getCoverity_stream_name());
-        }
-
-        if (!Utility.isStringNullOrBlank(scanStep.getCoverity_policy_view())) {
-            coverityParameters.put(ApplicationConstants.COVERITY_POLICY_VIEW_KEY, scanStep.getCoverity_policy_view());
-        }
-
-        if (!Utility.isStringNullOrBlank(scanStep.getCoverity_install_directory())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getCoverity_project_name())) {
             coverityParameters.put(
-                    ApplicationConstants.COVERITY_INSTALL_DIRECTORY_KEY, scanStep.getCoverity_install_directory());
+                    ApplicationConstants.COVERITY_PROJECT_NAME_KEY, securityScan.getCoverity_project_name());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getCoverity_version())) {
-            coverityParameters.put(ApplicationConstants.COVERITY_VERSION_KEY, scanStep.getCoverity_version());
-        }
-
-        if (scanStep.isCoverity_local() != null) {
-            coverityParameters.put(ApplicationConstants.COVERITY_LOCAL_KEY, scanStep.isCoverity_local());
-        }
-
-        if (scanStep.isCoverity_automation_prcomment() != null) {
+        if (!Utility.isStringNullOrBlank(securityScan.getCoverity_stream_name())) {
             coverityParameters.put(
-                    ApplicationConstants.COVERITY_AUTOMATION_PRCOMMENT_KEY, scanStep.isCoverity_automation_prcomment());
+                    ApplicationConstants.COVERITY_STREAM_NAME_KEY, securityScan.getCoverity_stream_name());
+        }
+
+        if (!Utility.isStringNullOrBlank(securityScan.getCoverity_policy_view())) {
+            coverityParameters.put(
+                    ApplicationConstants.COVERITY_POLICY_VIEW_KEY, securityScan.getCoverity_policy_view());
+        }
+
+        if (!Utility.isStringNullOrBlank(securityScan.getCoverity_install_directory())) {
+            coverityParameters.put(
+                    ApplicationConstants.COVERITY_INSTALL_DIRECTORY_KEY, securityScan.getCoverity_install_directory());
+        }
+
+        if (!Utility.isStringNullOrBlank(securityScan.getCoverity_version())) {
+            coverityParameters.put(ApplicationConstants.COVERITY_VERSION_KEY, securityScan.getCoverity_version());
+        }
+
+        if (securityScan.isCoverity_local() != null) {
+            coverityParameters.put(ApplicationConstants.COVERITY_LOCAL_KEY, securityScan.isCoverity_local());
+        }
+
+        if (securityScan.isCoverity_automation_prcomment() != null) {
+            coverityParameters.put(
+                    ApplicationConstants.COVERITY_AUTOMATION_PRCOMMENT_KEY,
+                    securityScan.isCoverity_automation_prcomment());
         }
 
         return coverityParameters;
     }
 
-    public static Map<String, Object> prepareBridgeParametersMap(SecurityScanStep scanStep) {
+    public static Map<String, Object> prepareBridgeParametersMap(SecurityScan securityScan) {
         Map<String, Object> bridgeParameters = new HashMap<>();
 
-        if (!Utility.isStringNullOrBlank(scanStep.getSynopsys_bridge_download_url())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getSynopsys_bridge_download_url())) {
             bridgeParameters.put(
-                    ApplicationConstants.SYNOPSYS_BRIDGE_DOWNLOAD_URL, scanStep.getSynopsys_bridge_download_url());
+                    ApplicationConstants.SYNOPSYS_BRIDGE_DOWNLOAD_URL, securityScan.getSynopsys_bridge_download_url());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getSynopsys_bridge_download_version())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getSynopsys_bridge_download_version())) {
             bridgeParameters.put(
                     ApplicationConstants.SYNOPSYS_BRIDGE_DOWNLOAD_VERSION,
-                    scanStep.getSynopsys_bridge_download_version());
+                    securityScan.getSynopsys_bridge_download_version());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getSynopsys_bridge_install_directory())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getSynopsys_bridge_install_directory())) {
             bridgeParameters.put(
                     ApplicationConstants.SYNOPSYS_BRIDGE_INSTALL_DIRECTORY,
-                    scanStep.getSynopsys_bridge_install_directory());
+                    securityScan.getSynopsys_bridge_install_directory());
         }
 
-        if (scanStep.isInclude_diagnostics() != null) {
-            bridgeParameters.put(ApplicationConstants.INCLUDE_DIAGNOSTICS_KEY, scanStep.isInclude_diagnostics());
+        if (securityScan.isInclude_diagnostics() != null) {
+            bridgeParameters.put(ApplicationConstants.INCLUDE_DIAGNOSTICS_KEY, securityScan.isInclude_diagnostics());
         }
 
-        if (scanStep.isNetwork_airgap() != null) {
-            bridgeParameters.put(ApplicationConstants.NETWORK_AIRGAP_KEY, scanStep.isNetwork_airgap());
+        if (securityScan.isNetwork_airgap() != null) {
+            bridgeParameters.put(ApplicationConstants.NETWORK_AIRGAP_KEY, securityScan.isNetwork_airgap());
         }
 
         return bridgeParameters;
     }
 
-    public static Map<String, Object> preparePolarisParametersMap(SecurityScanStep scanStep) {
+    public static Map<String, Object> preparePolarisParametersMap(SecurityScan securityScan) {
         Map<String, Object> polarisParametersMap = new HashMap<>();
 
-        if (!Utility.isStringNullOrBlank(scanStep.getPolaris_server_url())) {
-            polarisParametersMap.put(ApplicationConstants.POLARIS_SERVER_URL_KEY, scanStep.getPolaris_server_url());
+        if (!Utility.isStringNullOrBlank(securityScan.getPolaris_server_url())) {
+            polarisParametersMap.put(ApplicationConstants.POLARIS_SERVER_URL_KEY, securityScan.getPolaris_server_url());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getPolaris_access_token())) {
-            polarisParametersMap.put(ApplicationConstants.POLARIS_ACCESS_TOKEN_KEY, scanStep.getPolaris_access_token());
-        }
-
-        if (!Utility.isStringNullOrBlank(scanStep.getPolaris_application_name())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getPolaris_access_token())) {
             polarisParametersMap.put(
-                    ApplicationConstants.POLARIS_APPLICATION_NAME_KEY, scanStep.getPolaris_application_name());
+                    ApplicationConstants.POLARIS_ACCESS_TOKEN_KEY, securityScan.getPolaris_access_token());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getPolaris_project_name())) {
-            polarisParametersMap.put(ApplicationConstants.POLARIS_PROJECT_NAME_KEY, scanStep.getPolaris_project_name());
-        }
-
-        if (!Utility.isStringNullOrBlank(scanStep.getPolaris_assessment_types())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getPolaris_application_name())) {
             polarisParametersMap.put(
-                    ApplicationConstants.POLARIS_ASSESSMENT_TYPES_KEY, scanStep.getPolaris_assessment_types());
+                    ApplicationConstants.POLARIS_APPLICATION_NAME_KEY, securityScan.getPolaris_application_name());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getPolaris_triage())) {
-            polarisParametersMap.put(ApplicationConstants.POLARIS_TRIAGE_KEY, scanStep.getPolaris_triage());
+        if (!Utility.isStringNullOrBlank(securityScan.getPolaris_project_name())) {
+            polarisParametersMap.put(
+                    ApplicationConstants.POLARIS_PROJECT_NAME_KEY, securityScan.getPolaris_project_name());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getPolaris_branch_name())) {
-            polarisParametersMap.put(ApplicationConstants.POLARIS_BRANCH_NAME_KEY, scanStep.getPolaris_branch_name());
+        if (!Utility.isStringNullOrBlank(securityScan.getPolaris_assessment_types())) {
+            polarisParametersMap.put(
+                    ApplicationConstants.POLARIS_ASSESSMENT_TYPES_KEY, securityScan.getPolaris_assessment_types());
         }
 
-        //        if (!Utility.isStringNullOrBlank(scanStep.getBridge_polaris_branch_parent_name())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getPolaris_triage())) {
+            polarisParametersMap.put(ApplicationConstants.POLARIS_TRIAGE_KEY, securityScan.getPolaris_triage());
+        }
+
+        if (!Utility.isStringNullOrBlank(securityScan.getPolaris_branch_name())) {
+            polarisParametersMap.put(
+                    ApplicationConstants.POLARIS_BRANCH_NAME_KEY, securityScan.getPolaris_branch_name());
+        }
+
+        //        if (!Utility.isStringNullOrBlank(securityScan.getBridge_polaris_branch_parent_name())) {
         //            polarisParametersMap.put(ApplicationConstants.POLARIS_BRANCH_PARENT_NAME_KEY,
-        // scanStep.getBridge_polaris_branch_parent_name());
+        // securityScan.getBridge_polaris_branch_parent_name());
         //        }
 
         return polarisParametersMap;
     }
 
-    public static Map<String, Object> prepareSarifReportParametersMap(SecurityScanStep scanStep) {
+    public static Map<String, Object> prepareSarifReportParametersMap(SecurityScan securityScan) {
         Map<String, Object> sarifParameters = new HashMap<>();
 
-        if (scanStep.isBlackduck_reports_sarif_create() != null) {
+        if (securityScan.isBlackduck_reports_sarif_create() != null) {
             sarifParameters.put(
                     ApplicationConstants.BLACKDUCK_REPORTS_SARIF_CREATE_KEY,
-                    scanStep.isBlackduck_reports_sarif_create());
+                    securityScan.isBlackduck_reports_sarif_create());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getBlackduck_reports_sarif_file_path())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getBlackduck_reports_sarif_file_path())) {
             sarifParameters.put(
                     ApplicationConstants.BLACKDUCK_REPORTS_SARIF_FILE_PATH_KEY,
-                    scanStep.getBlackduck_reports_sarif_file_path());
+                    securityScan.getBlackduck_reports_sarif_file_path());
         }
 
-        if (scanStep.isBlackduck_reports_sarif_groupSCAIssues() != null) {
+        if (securityScan.isBlackduck_reports_sarif_groupSCAIssues() != null) {
             sarifParameters.put(
                     ApplicationConstants.BLACKDUCK_REPORTS_SARIF_GROUPSCAISSUES_KEY,
-                    scanStep.isBlackduck_reports_sarif_groupSCAIssues());
+                    securityScan.isBlackduck_reports_sarif_groupSCAIssues());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getBlackduck_reports_sarif_severities())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getBlackduck_reports_sarif_severities())) {
             sarifParameters.put(
                     ApplicationConstants.BLACKDUCK_REPORTS_SARIF_SEVERITIES_KEY,
-                    scanStep.getBlackduck_reports_sarif_severities());
+                    securityScan.getBlackduck_reports_sarif_severities());
         }
 
         return sarifParameters;

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ApplicationConstants.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/ApplicationConstants.java
@@ -12,7 +12,9 @@ public class ApplicationConstants {
     public static final String BRIDGE_ZIP_FILE_FORMAT = "bridge.zip";
     public static final String PLATFORM_LINUX = "linux64";
     public static final String PLATFORM_WINDOWS = "win64";
-    public static final String PLATFORM_MAC = "macosx";
+    public static final String PLATFORM_MAC_ARM = "macos_arm";
+    public static final String PLATFORM_MACOSX = "macosx";
+    public static final String MAC_ARM_COMPATIBLE_BRIDGE_VERSION = "2.1.0";
     public static final String DEFAULT_DIRECTORY_NAME = "synopsys-bridge";
     public static final String BRIDGE_REPORT_DIRECTORY = ".bridge";
     public static final String DEFAULT_BLACKDUCK_SARIF_REPORT_FILE_PATH = ".bridge/Blackduck SARIF Generator/";
@@ -95,4 +97,8 @@ public class ApplicationConstants {
 
     public static final String BRANCH_NAME = "BRANCH_NAME";
     public static final String GIT_URL = "GIT_URL";
+
+    public static final String BITBUCKET_BRANCH_SOURCE_PLUGIN_NAME = "cloudbees-bitbucket-branch-source";
+    public static final String GITHUB_BRANCH_SOURCE_PLUGIN_NAME = "github-branch-source";
+    public static final String GITLAB_BRANCH_SOURCE_PLUGIN_NAME = "gitlab-branch-source";
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/OsArchTask.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/OsArchTask.java
@@ -1,0 +1,13 @@
+package io.jenkins.plugins.synopsys.security.scan.global;
+
+import hudson.FilePath;
+import hudson.remoting.VirtualChannel;
+import java.io.File;
+import jenkins.MasterToSlaveFileCallable;
+
+public class OsArchTask extends MasterToSlaveFileCallable<String> implements FilePath.FileCallable<String> {
+    @Override
+    public String invoke(File workspace, VirtualChannel channel) {
+        return System.getProperty("os.arch").toLowerCase();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/Utility.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/Utility.java
@@ -11,6 +11,9 @@ import java.net.MalformedURLException;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import jenkins.model.Jenkins;
 
 public class Utility {
 
@@ -41,6 +44,25 @@ public class Utility {
         }
 
         return os;
+    }
+
+    public static String getAgentOsArch(FilePath workspace, TaskListener listener) {
+        String arch = null;
+        LoggerWrapper logger = new LoggerWrapper(listener);
+
+        if (workspace.isRemote()) {
+            try {
+                arch = workspace.act(new OsArchTask());
+            } catch (IOException | InterruptedException e) {
+                logger.error("An exception occurred while fetching OS architecture information for the agent node: "
+                        + e.getMessage());
+                Thread.currentThread().interrupt();
+            }
+        } else {
+            arch = System.getProperty("os.arch").toLowerCase();
+        }
+
+        return arch;
     }
 
     public static void removeFile(String filePath, FilePath workspace, TaskListener listener) {
@@ -157,5 +179,21 @@ public class Utility {
         }
 
         return proxyUrlString;
+    }
+
+    public static Map<String, Boolean> installedBranchSourceDependcies() {
+        Map<String, Boolean> installedBranchSourceDependencies = new HashMap<>();
+
+        if (Jenkins.getInstance().getPlugin(ApplicationConstants.BITBUCKET_BRANCH_SOURCE_PLUGIN_NAME) != null) {
+            installedBranchSourceDependencies.put(ApplicationConstants.BITBUCKET_BRANCH_SOURCE_PLUGIN_NAME, true);
+        }
+        if (Jenkins.getInstance().getPlugin(ApplicationConstants.GITHUB_BRANCH_SOURCE_PLUGIN_NAME) != null) {
+            installedBranchSourceDependencies.put(ApplicationConstants.GITHUB_BRANCH_SOURCE_PLUGIN_NAME, true);
+        }
+        if (Jenkins.getInstance().getPlugin(ApplicationConstants.GITLAB_BRANCH_SOURCE_PLUGIN_NAME) != null) {
+            installedBranchSourceDependencies.put(ApplicationConstants.GITLAB_BRANCH_SOURCE_PLUGIN_NAME, true);
+        }
+
+        return installedBranchSourceDependencies;
     }
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/enums/SecurityProduct.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/global/enums/SecurityProduct.java
@@ -1,7 +1,17 @@
 package io.jenkins.plugins.synopsys.security.scan.global.enums;
 
 public enum SecurityProduct {
-    BLACKDUCK,
-    COVERITY,
-    POLARIS;
+    BLACKDUCK("Black Duck"),
+    COVERITY("Coverity"),
+    POLARIS("Polaris");
+
+    private String productLabel;
+
+    SecurityProduct(String productLabel) {
+        this.productLabel = productLabel;
+    }
+
+    public String getProductLabel() {
+        return productLabel;
+    }
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/ScannerArgumentService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/ScannerArgumentService.java
@@ -47,13 +47,16 @@ public class ScannerArgumentService {
         this.logger = new LoggerWrapper(listener);
     }
 
-    public List<String> getCommandLineArgs(Map<String, Object> scanParameters, FilePath bridgeInstallationPath)
+    public List<String> getCommandLineArgs(
+            Map<String, Boolean> installedBranchSourceDependencies,
+            Map<String, Object> scanParameters,
+            FilePath bridgeInstallationPath)
             throws PluginExceptionHandler {
         List<String> commandLineArgs = new ArrayList<>();
 
         commandLineArgs.add(getBridgeRunCommand(bridgeInstallationPath));
 
-        commandLineArgs.addAll(getSecurityProductSpecificCommands(scanParameters));
+        commandLineArgs.addAll(getSecurityProductSpecificCommands(installedBranchSourceDependencies, scanParameters));
 
         if (Objects.equals(scanParameters.get(ApplicationConstants.INCLUDE_DIAGNOSTICS_KEY), true)) {
             commandLineArgs.add(BridgeParams.DIAGNOSTICS_OPTION);
@@ -76,7 +79,8 @@ public class ScannerArgumentService {
         }
     }
 
-    private List<String> getSecurityProductSpecificCommands(Map<String, Object> scanParameters)
+    private List<String> getSecurityProductSpecificCommands(
+            Map<String, Boolean> installedBranchSourceDependencies, Map<String, Object> scanParameters)
             throws PluginExceptionHandler {
         ScanParametersService scanParametersService = new ScanParametersService(listener);
         Set<String> securityProducts = scanParametersService.getSynopsysSecurityProducts(scanParameters);
@@ -84,7 +88,8 @@ public class ScannerArgumentService {
         boolean fixPrOrPrComment = isFixPrOrPrCommentValueSet(scanParameters);
 
         SCMRepositoryService scmRepositoryService = new SCMRepositoryService(listener, envVars);
-        Object scmObject = scmRepositoryService.fetchSCMRepositoryDetails(scanParameters, fixPrOrPrComment);
+        Object scmObject = scmRepositoryService.fetchSCMRepositoryDetails(
+                installedBranchSourceDependencies, scanParameters, fixPrOrPrComment);
 
         List<String> scanCommands = new ArrayList<>();
 

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/SCMRepositoryService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/SCMRepositoryService.java
@@ -84,6 +84,10 @@ public class SCMRepositoryService {
 
     public SCMSource findSCMSource() {
         String jobName = envVars.get(ApplicationConstants.ENV_JOB_NAME_KEY);
+        String branchName = envVars.get(ApplicationConstants.ENV_BRANCH_NAME_KEY);
+        if (branchName != null) {
+            jobName = jobName.substring(0, jobName.indexOf("/"));
+        }
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         SCMSourceOwner owner = jenkins != null ? jenkins.getItemByFullName(jobName, SCMSourceOwner.class) : null;
         if (owner != null) {

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/SCMRepositoryService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/SCMRepositoryService.java
@@ -24,26 +24,34 @@ public class SCMRepositoryService {
         this.envVars = envVars;
     }
 
-    public Object fetchSCMRepositoryDetails(Map<String, Object> scanParameters, boolean isFixPrOrPrComment)
+    public Object fetchSCMRepositoryDetails(
+            Map<String, Boolean> installedBranchSourceDependencies,
+            Map<String, Object> scanParameters,
+            boolean isFixPrOrPrComment)
             throws PluginExceptionHandler {
         Integer projectRepositoryPullNumber = envVars.get(ApplicationConstants.ENV_CHANGE_ID_KEY) != null
                 ? Integer.parseInt(envVars.get(ApplicationConstants.ENV_CHANGE_ID_KEY))
                 : null;
 
         SCMSource scmSource = findSCMSource();
-        if (scmSource instanceof BitbucketSCMSource) {
+        if (scmSource instanceof BitbucketSCMSource
+                && installedBranchSourceDependencies.containsKey(
+                        ApplicationConstants.BITBUCKET_BRANCH_SOURCE_PLUGIN_NAME)
+                && installedBranchSourceDependencies.get(ApplicationConstants.BITBUCKET_BRANCH_SOURCE_PLUGIN_NAME)) {
             BitbucketRepositoryService bitbucketRepositoryService = new BitbucketRepositoryService(listener);
             BitbucketSCMSource bitbucketSCMSource = (BitbucketSCMSource) scmSource;
             return bitbucketRepositoryService.fetchBitbucketRepositoryDetails(
                     scanParameters, bitbucketSCMSource, projectRepositoryPullNumber, isFixPrOrPrComment);
-        } else if (scmSource instanceof GitHubSCMSource) {
+        } else if (scmSource instanceof GitHubSCMSource
+                && installedBranchSourceDependencies.containsKey(ApplicationConstants.GITHUB_BRANCH_SOURCE_PLUGIN_NAME)
+                && installedBranchSourceDependencies.get(ApplicationConstants.GITHUB_BRANCH_SOURCE_PLUGIN_NAME)) {
             GithubRepositoryService githubRepositoryService = new GithubRepositoryService(listener);
             GitHubSCMSource gitHubSCMSource = (GitHubSCMSource) scmSource;
 
             String repositoryOwner = gitHubSCMSource.getRepoOwner();
             String repositoryName = gitHubSCMSource.getRepository();
             String branchName = envVars.get(ApplicationConstants.BRANCH_NAME);
-            String repositoryUrl = envVars.get(ApplicationConstants.GIT_URL);
+            String apiUri = gitHubSCMSource.getApiUri();
 
             return githubRepositoryService.createGithubObject(
                     scanParameters,
@@ -51,13 +59,15 @@ public class SCMRepositoryService {
                     repositoryOwner,
                     projectRepositoryPullNumber,
                     branchName,
-                    repositoryUrl,
-                    isFixPrOrPrComment);
-        } else if (scmSource instanceof GitLabSCMSource) {
+                    isFixPrOrPrComment,
+                    apiUri);
+        } else if (scmSource instanceof GitLabSCMSource
+                && installedBranchSourceDependencies.containsKey(ApplicationConstants.GITLAB_BRANCH_SOURCE_PLUGIN_NAME)
+                && installedBranchSourceDependencies.get(ApplicationConstants.GITLAB_BRANCH_SOURCE_PLUGIN_NAME)) {
             GitlabRepositoryService gitlabRepositoryService = new GitlabRepositoryService(listener);
             GitLabSCMSource gitLabSCMSource = (GitLabSCMSource) scmSource;
 
-            String repositoryUrl = envVars.get(ApplicationConstants.GIT_URL);
+            String repositoryUrl = gitLabSCMSource.getHttpRemote();
             String branchName = envVars.get(ApplicationConstants.BRANCH_NAME);
             String repositoryName = gitLabSCMSource.getProjectPath();
 
@@ -73,8 +83,7 @@ public class SCMRepositoryService {
     }
 
     public SCMSource findSCMSource() {
-        String jobName = envVars.get(ApplicationConstants.ENV_JOB_NAME_KEY)
-                .substring(0, envVars.get(ApplicationConstants.ENV_JOB_NAME_KEY).indexOf("/"));
+        String jobName = envVars.get(ApplicationConstants.ENV_JOB_NAME_KEY);
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         SCMSourceOwner owner = jenkins != null ? jenkins.getItemByFullName(jobName, SCMSourceOwner.class) : null;
         if (owner != null) {

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/github/GithubRepositoryService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/github/GithubRepositoryService.java
@@ -7,13 +7,13 @@ import io.jenkins.plugins.synopsys.security.scan.global.LogMessages;
 import io.jenkins.plugins.synopsys.security.scan.global.LoggerWrapper;
 import io.jenkins.plugins.synopsys.security.scan.global.Utility;
 import io.jenkins.plugins.synopsys.security.scan.input.scm.github.Github;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Map;
+import org.apache.commons.lang.StringUtils;
 
 public class GithubRepositoryService {
     private final LoggerWrapper logger;
     private String GITHUB_CLOUD_HOST_URL = "https://github.com/";
+    private String GITHUB_CLOUD_API_URI = "https://api.github.com";
     private String INVALID_GITHUB_REPO_URL = "Invalid Github repository URL";
 
     public GithubRepositoryService(TaskListener listener) {
@@ -26,8 +26,8 @@ public class GithubRepositoryService {
             String repositoryOwner,
             Integer projectRepositoryPullNumber,
             String branchName,
-            String repositoryUrl,
-            boolean isFixPrOrPrComment)
+            boolean isFixPrOrPrComment,
+            String githubApiUri)
             throws PluginExceptionHandler {
         String githubToken = (String) scanParameters.get(ApplicationConstants.GITHUB_TOKEN_KEY);
 
@@ -44,7 +44,8 @@ public class GithubRepositoryService {
         github.getRepository().getPull().setNumber(projectRepositoryPullNumber);
         github.getRepository().getBranch().setName(branchName);
 
-        String githubHostUrl = extractGitHubHost(repositoryUrl);
+        String githubHostUrl = extractGitHubHost(githubApiUri);
+
         if (githubHostUrl.equals(INVALID_GITHUB_REPO_URL)) {
             throw new PluginExceptionHandler(INVALID_GITHUB_REPO_URL);
         } else {
@@ -58,13 +59,12 @@ public class GithubRepositoryService {
         return github;
     }
 
-    public String extractGitHubHost(String url) {
+    public String extractGitHubHost(String githubApiUri) {
         try {
-            URL gitHubUrl = new URL(url);
-            int port = gitHubUrl.getPort();
-            return String.format(
-                    "%s://%s%s/", gitHubUrl.getProtocol(), gitHubUrl.getHost(), (port == -1) ? "" : ":" + port);
-        } catch (MalformedURLException e) {
+            return GITHUB_CLOUD_API_URI.equals(githubApiUri)
+                    ? GITHUB_CLOUD_HOST_URL
+                    : String.format("%s", StringUtils.removeEnd(githubApiUri, "api/v3"));
+        } catch (Exception e) {
             return INVALID_GITHUB_REPO_URL;
         }
     }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/gitlab/GitlabRepositoryService.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/service/scm/gitlab/GitlabRepositoryService.java
@@ -43,6 +43,7 @@ public class GitlabRepositoryService {
         gitlab.getRepository().getPull().setNumber(projectRepositoryPullNumber);
 
         String gitlabHostUrl = extractGitlabHost(repositoryUrl);
+
         if (gitlabHostUrl.equals(INVALID_GITLAB_REPO_URL)) {
             throw new PluginExceptionHandler(INVALID_GITLAB_REPO_URL);
         } else {

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/config.jelly
@@ -1,0 +1,174 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+    <div id="product">
+        <f:entry field="product" title="Select Security Product">
+            <f:select/>
+        </f:entry>
+    </div>
+
+    <div id="blackduck" style="display: none;">
+        <f:section title="Black Duck Parameters">
+            <f:entry field="blackduck_scan_failure_severities" title="Black Duck Scan Failure Severities (Optional)">
+                <f:textbox/>
+            </f:entry>
+            <f:entry field="blackduck_download_url" title="Black Duck Download URL (Optional)">
+                <f:textbox/>
+            </f:entry>
+            <f:entry field="blackduck_scan_full" title="Black Duck Full Scan (Optional)">
+                <f:checkbox/>
+            </f:entry>
+<!--            <f:entry field="blackduck_automation_prcomment" title="Add Comments to Pull Requests (Optional)">-->
+<!--                <f:checkbox/>-->
+<!--            </f:entry>-->
+            <!--        <f:entry field="bridge_blackduck_automation_fixpr" title="Create Fix Pull Requests">-->
+            <!--            <f:checkbox/>-->
+            <!--        </f:entry>-->
+        </f:section>
+        <f:section title="SARIF Report Options">
+            <f:entry field="blackduck_reports_sarif_create" title="Generate SARIF Report for Black Duck Issues (Optional)">
+                <f:checkbox/>
+            </f:entry>
+            <f:entry field="blackduck_reports_sarif_groupSCAIssues" title="Group SCA Issues by Component (Optional)">
+                <f:checkbox/>
+            </f:entry>
+            <f:entry field="blackduck_reports_sarif_file_path" title="Black Duck SARIF Report File Path (Optional)">
+                <f:textbox/>
+            </f:entry>
+            <f:entry field="blackduck_reports_sarif_severities" title="Black Duck SARIF Report Severities (Optional)">
+                <f:textbox/>
+            </f:entry>
+        </f:section>
+    </div>
+
+    <div id="coverity" style="display: none;">
+        <f:section title="Coverity Parameters">
+            <f:entry field="coverity_project_name" title="Coverity Project Name (Optional)">
+                <f:textbox/>
+            </f:entry>
+            <f:entry field="coverity_stream_name" title="Coverity Stream Name (Optional)">
+                <f:textbox/>
+            </f:entry>
+            <f:entry field="coverity_policy_view" title="Coverity Policy View (Optional)">
+                <f:textbox/>
+            </f:entry>
+            <f:entry field="coverity_version" title="Coverity Version Number (Optional)">
+                <f:textbox/>
+            </f:entry>
+<!--            <f:entry field="coverity_automation_prcomment" title="Add Comments to Pull Requests (Optional)">-->
+<!--                <f:checkbox/>-->
+<!--            </f:entry>-->
+            <f:entry field="coverity_local" title="Coverity Local Analysis (Optional)">
+                <f:checkbox/>
+            </f:entry>
+        </f:section>
+    </div>
+
+    <div id="polaris" style="display: none;">
+        <f:section title="Polaris Parameters">
+            <f:entry field="polaris_application_name" title="Polaris Application Name (Mandatory)">
+                <f:textbox/>
+            </f:entry>
+            <f:entry field="polaris_project_name" title="Polaris Project Name (Mandatory)">
+                <f:textbox/>
+            </f:entry>
+            <f:entry field="polaris_assessment_types" title="Polaris Assessment Types (Mandatory)">
+                <f:textbox/>
+            </f:entry>
+            <f:entry field="polaris_triage" title="Polaris Triage (Optional)">
+                <f:textbox/>
+            </f:entry>
+            <f:entry field="polaris_branch_name" title="Polaris Branch Name (Mandatory)">
+                <f:textbox/>
+            </f:entry>
+        </f:section>
+    </div>
+
+    <f:section title="Additional Options">
+        <f:entry field="include_diagnostics" title="Include Diagnostics (Optional)">
+            <f:checkbox/>
+        </f:entry>
+        <f:entry field="network_airgap" title="Network Airgap (Optional)">
+            <f:checkbox/>
+        </f:entry>
+    </f:section>
+
+    <script type="text/javascript">
+
+        var selectedOption = document.querySelector('select[name="_.product"]')?.value;
+
+        if(selectedOption &amp;&amp; selectedOption !== 'select') {
+            document.getElementById(selectedOption).style.display = 'block';
+        }
+
+        function hideAllDivs(blackduckDiv, coverityDiv, polarisDiv) {
+            if(blackduckDiv) {
+                blackduckDiv.style.display='none';
+            }
+            if(coverityDiv) {
+                coverityDiv.style.display='none';
+            }
+            if(polarisDiv) {
+                polarisDiv.style.display='none';
+            }
+        }
+
+        function hideAParticularDiv(div) {
+            if(div) {
+                div.style.display = 'none';
+            }
+        }
+
+        function showDiv(div) {
+            if (div) {
+                div.style.display = 'block';
+            }
+        }
+
+        function clearInputFields(div) {
+            if (div) {
+                var inputFields = div.querySelectorAll('input[type="text"], input[type="checkbox"]');
+                inputFields.forEach(function (field) {
+                    if (field.type === 'text') {
+                        field.value = '';
+                    } else if (field.type === 'checkbox') {
+                        field.checked = false;
+                    }
+                });
+            }
+        }
+
+        document.addEventListener('change', function() {
+            var selectedOption = document.querySelector('select[name="_.product"]')?.value;
+            var blackduckDiv = document.getElementById('blackduck');
+            var coverityDiv = document.getElementById('coverity');
+            var polarisDiv = document.getElementById('polaris');
+
+            if (selectedOption === 'blackduck') {
+                clearInputFields(coverityDiv);
+                hideAParticularDiv(polarisDiv);
+                clearInputFields(polarisDiv);
+                hideAParticularDiv(coverityDiv);
+                showDiv(blackduckDiv);
+            } else if (selectedOption === 'coverity') {
+                clearInputFields(blackduckDiv);
+                hideAParticularDiv(blackduckDiv);
+                clearInputFields(polarisDiv);
+                hideAParticularDiv(polarisDiv);
+                showDiv(coverityDiv);
+            } else if (selectedOption === 'polaris') {
+                clearInputFields(blackduckDiv);
+                hideAParticularDiv(blackduckDiv);
+                clearInputFields(coverityDiv);
+                hideAParticularDiv(coverityDiv);
+                showDiv(polarisDiv);
+            }else if (selectedOption === 'select') {
+                hideAllDivs(blackduckDiv, coverityDiv, polarisDiv);
+            }
+
+        });
+
+
+    </script>
+
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_automation_prcomment.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_automation_prcomment.html
@@ -1,0 +1,3 @@
+<div>
+    Add automatic pull request comment based on Black Duck scan result. Supported values: <code>true</code> or <code>false</code>
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_download_url.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_download_url.html
@@ -1,0 +1,3 @@
+<div>
+    Specify Black Duck download URL
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_scan_failure_severities.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_scan_failure_severities.html
@@ -1,0 +1,4 @@
+<div>
+    Specify scan failure severities of Black Duck. Supported values: <code>ALL</code>, <code>NONE</code>, <code>BLOCKER</code>,
+    <code>CRITICAL</code>, <code>MAJOR</code>, <code>MINOR</code>, <code>OK</code>, <code>TRIVIAL</code>, <code>UNSPECIFIED</code>
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_scan_full.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_scan_full.html
@@ -1,0 +1,3 @@
+<div>
+    Specifies whether full scan is required or not. Supported values: <code>true</code> or <code>false</code>
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-coverity_automation_prcomment.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-coverity_automation_prcomment.html
@@ -1,0 +1,3 @@
+<div>
+    Coverity security testing as pull request comment. Supported values: <code>true</code> or <code>false</code>
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-coverity_local.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-coverity_local.html
@@ -1,0 +1,3 @@
+<div>
+    Coverity Local Analysis. Supported values: <code>true</code> or <code>false</code>
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-coverity_policy_view.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-coverity_policy_view.html
@@ -1,0 +1,3 @@
+<div>
+    ID number/Name of a saved view to apply as a <b>'break the build'</b> policy
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-coverity_project_name.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-coverity_project_name.html
@@ -1,0 +1,3 @@
+<div>
+    Project name in Coverity
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-coverity_stream_name.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-coverity_stream_name.html
@@ -1,0 +1,3 @@
+<div>
+    Stream name in Coverity
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-coverity_version.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-coverity_version.html
@@ -1,0 +1,3 @@
+<div>
+    Specific Coverity version to download, rather than opting for the latest version
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-include_diagnostics.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-include_diagnostics.html
@@ -1,0 +1,3 @@
+<div>
+    Bridge diagnostics will be uploaded in Jenkins Archive Artifact. Supported values: <code>true</code> or <code>false</code>
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-network_airgap.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-network_airgap.html
@@ -1,0 +1,3 @@
+<div>
+    Network airgap. Supported values: <code>true</code> or <code>false</code>
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_application_name.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_application_name.html
@@ -1,0 +1,3 @@
+<div>
+    Application name created in the Polaris server
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_assessment_types.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_assessment_types.html
@@ -1,0 +1,3 @@
+<div>
+    Polaris assessment types. Supported values: <code>SCA</code> or <code>SAST</code> or both <code>SCA, SAST</code>
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_branch_name.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_branch_name.html
@@ -1,0 +1,3 @@
+<div>
+    Branch name in the Polaris Server
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_project_name.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_project_name.html
@@ -1,0 +1,3 @@
+<div>
+    Project name created in the Polaris server
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_triage.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_triage.html
@@ -1,0 +1,3 @@
+<div>
+    Polaris Triage. Supported values: <code>REQUIRED</code>REQUIRED or <code>NOT_REQUIRED</code>NOT_REQUIRED or <code>NOT_ENTITLED</code>
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-product.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-product.html
@@ -1,0 +1,3 @@
+<div>
+    Please select the synopsys security product. Supported products are <b>Black Duck</b>, <b>Coverity</b> and <b>Polaris</b>
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/global/ScannerGlobalConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/global/ScannerGlobalConfig/config.jelly
@@ -80,11 +80,11 @@
                <c:select/>
             </f:entry>
 
-            <f:entry field="githubCredentialsId" title="Github Token (Optional)">
+            <f:entry field="githubCredentialsId" title="GitHub Token (Optional)">
                 <c:select/>
             </f:entry>
 
-            <f:entry field="gitlabCredentialsId" title="Gitlab Token (Optional)">
+            <f:entry field="gitlabCredentialsId" title="GitLab Token (Optional)">
                 <c:select/>
             </f:entry>
 

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/global/ScannerGlobalConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/global/ScannerGlobalConfig/config.jelly
@@ -28,7 +28,7 @@
             </f:entry>
             <div class="button-container">
                 <div class="flex-1">
-                    <f:validateButton method="testBlackDuckConnection" title="Test connection" progress="Testing..." with="blackDuckUrl,blackDuckCredentialsId"/>
+                    <f:validateButton method="testBlackDuckConnection" title="Test Connection" progress="Testing..." with="blackDuckUrl,blackDuckCredentialsId"/>
                 </div>
                 <f:entry>
                     <button type="button" class="jenkins-button ml-7" onclick="clearTabFieldsAndTestConnectionMessages('BLACKDUCKSection')">Clear</button>
@@ -49,7 +49,7 @@
             </f:entry>
             <div class="button-container">
                 <div class="flex-1">
-                    <f:validateButton method="testCoverityConnection" title="Test connection" progress="Testing..." with="coverityConnectUrl,coverityCredentialsId"/>
+                    <f:validateButton method="testCoverityConnection" title="Test Connection" progress="Testing..." with="coverityConnectUrl,coverityCredentialsId"/>
                 </div>
                 <f:entry>
                     <button type="button" class="jenkins-button ml-7" onclick="clearTabFieldsAndTestConnectionMessages('COVERITYSection')">Clear</button>
@@ -67,7 +67,7 @@
             </f:entry>
             <div class="button-container">
                 <div class="flex-1">
-                    <f:validateButton method="testPolarisConnection" title="Test connection" progress="Testing..." with="polarisServerUrl,polarisCredentialsId"/>
+                    <f:validateButton method="testPolarisConnection" title="Test Connection" progress="Testing..." with="polarisServerUrl,polarisCredentialsId"/>
                 </div>
                 <f:entry>
                     <button type="button" class="jenkins-button ml-7" onclick="clearTabFieldsAndTestConnectionMessages('POLARISSection')">Clear</button>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/global/ScannerGlobalConfig/help-githubCredentialsId.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/global/ScannerGlobalConfig/help-githubCredentialsId.html
@@ -1,3 +1,3 @@
 <div>
-  Provide the Github API access token through which PR Comment will be added.
+  Provide the GitHub API access token through which PR Comment will be added.
 </div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/global/ScannerGlobalConfig/help-gitlabCredentialsId.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/global/ScannerGlobalConfig/help-gitlabCredentialsId.html
@@ -1,3 +1,3 @@
 <div>
-  Provide the Gitlab API access token through which PR Comment will be added.
+  Provide the GitLab API access token through which PR Comment will be added.
 </div>

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/global/UtilityTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/global/UtilityTest.java
@@ -9,11 +9,7 @@ import hudson.model.TaskListener;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.net.Authenticator;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.PasswordAuthentication;
-import java.net.URL;
+import java.net.*;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,6 +52,13 @@ public class UtilityTest {
         String os = Utility.getAgentOs(workspace, listenerMock);
 
         assertEquals(System.getProperty("os.name").toLowerCase(), os);
+    }
+
+    @Test
+    public void getAgentOsArchTest() {
+        String arch = Utility.getAgentOsArch(workspace, listenerMock);
+
+        assertEquals(System.getProperty("os.arch").toLowerCase(), arch);
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/ScannerArgumentServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/ScannerArgumentServiceTest.java
@@ -44,6 +44,7 @@ public class ScannerArgumentServiceTest {
     private ScannerArgumentService scannerArgumentService;
     private final TaskListener listenerMock = Mockito.mock(TaskListener.class);
     private final EnvVars envVarsMock = Mockito.mock(EnvVars.class);
+    private final String CLOUD_API_URI = "https://api.github.com";
     private FilePath workspace;
     private final String TOKEN = "MDJDSROSVC56FAKEKEY";
 
@@ -234,13 +235,7 @@ public class ScannerArgumentServiceTest {
 
         try {
             Github github = githubRepositoryService.createGithubObject(
-                    scanParametersMap,
-                    "fake-repo",
-                    "fake-owner",
-                    1,
-                    "fake-branch",
-                    "https://github.com/user/fake-repo.git",
-                    true);
+                    scanParametersMap, "fake-repo", "fake-owner", 1, "fake-branch", true, CLOUD_API_URI);
             String inputJsonPath = scannerArgumentService.createBridgeInputJson(
                     coverity, github, true, null, null, ApplicationConstants.COVERITY_INPUT_JSON_PREFIX);
             Path filePath = Paths.get(inputJsonPath);
@@ -313,7 +308,11 @@ public class ScannerArgumentServiceTest {
         blackDuckParametersMap.put(ApplicationConstants.BLACKDUCK_AUTOMATION_PRCOMMENT_KEY, false);
         blackDuckParametersMap.put(ApplicationConstants.INCLUDE_DIAGNOSTICS_KEY, true);
 
-        List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(blackDuckParametersMap, workspace);
+        Map<String, Boolean> installedDependencies = new HashMap<>();
+        installedDependencies.put(ApplicationConstants.BITBUCKET_BRANCH_SOURCE_PLUGIN_NAME, true);
+
+        List<String> commandLineArgs =
+                scannerArgumentService.getCommandLineArgs(installedDependencies, blackDuckParametersMap, workspace);
 
         if (getOSNameForTest().contains("win")) {
             assertEquals(
@@ -348,7 +347,11 @@ public class ScannerArgumentServiceTest {
         coverityParameters.put(ApplicationConstants.COVERITY_PASSPHRASE_KEY, "fakeUserPassword");
         coverityParameters.put(ApplicationConstants.INCLUDE_DIAGNOSTICS_KEY, true);
 
-        List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(coverityParameters, workspace);
+        Map<String, Boolean> installedDependencies = new HashMap<>();
+        installedDependencies.put(ApplicationConstants.BITBUCKET_BRANCH_SOURCE_PLUGIN_NAME, true);
+
+        List<String> commandLineArgs =
+                scannerArgumentService.getCommandLineArgs(installedDependencies, coverityParameters, workspace);
 
         if (getOSNameForTest().contains("win")) {
             assertEquals(
@@ -383,7 +386,11 @@ public class ScannerArgumentServiceTest {
         polarisParameters.put(ApplicationConstants.POLARIS_APPLICATION_NAME_KEY, "Fake-application-name");
         polarisParameters.put(ApplicationConstants.POLARIS_PROJECT_NAME_KEY, "fake-project-name");
 
-        List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(polarisParameters, workspace);
+        Map<String, Boolean> installedDependencies = new HashMap<>();
+        installedDependencies.put(ApplicationConstants.BITBUCKET_BRANCH_SOURCE_PLUGIN_NAME, true);
+
+        List<String> commandLineArgs =
+                scannerArgumentService.getCommandLineArgs(installedDependencies, polarisParameters, workspace);
 
         if (getOSNameForTest().contains("win")) {
             assertEquals(

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParameterServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/bridge/BridgeDownloadParameterServiceTest.java
@@ -1,6 +1,9 @@
 package io.jenkins.plugins.synopsys.security.scan.service.bridge;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.FilePath;
 import hudson.model.TaskListener;
@@ -147,6 +150,36 @@ public class BridgeDownloadParameterServiceTest {
         assertNotNull(result.getBridgeDownloadUrl());
         assertNotNull(result.getBridgeDownloadVersion());
         assertNotNull(result.getBridgeInstallationPath());
+    }
+
+    @Test
+    void getPlatformTest() {
+        String osName = System.getProperty("os.name").toLowerCase();
+        String osArch = System.getProperty("os.arch").toLowerCase();
+
+        String platform = bridgeDownloadParametersService.getPlatform(null);
+
+        assertNotNull(platform);
+
+        if (osName.contains("win")) {
+            assertEquals(ApplicationConstants.PLATFORM_WINDOWS, platform);
+        } else if (osName.contains("mac")) {
+            if (osArch.startsWith("arm") || osArch.startsWith("aarch")) {
+                assertEquals(ApplicationConstants.PLATFORM_MAC_ARM, platform);
+            } else {
+                assertEquals(ApplicationConstants.PLATFORM_MACOSX, platform);
+            }
+        } else {
+            assertEquals(ApplicationConstants.PLATFORM_LINUX, platform);
+        }
+    }
+
+    @Test
+    public void isVersionCompatibleForMacARMTest() {
+        assertTrue(bridgeDownloadParametersService.isVersionCompatibleForMacARM("2.1.0"));
+        assertTrue(bridgeDownloadParametersService.isVersionCompatibleForMacARM("2.2.38"));
+        assertFalse(bridgeDownloadParametersService.isVersionCompatibleForMacARM("2.0.0"));
+        assertFalse(bridgeDownloadParametersService.isVersionCompatibleForMacARM("1.2.12"));
     }
 
     public String getHomeDirectory() {

--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/scm/github/GithubRepositoryServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/scm/github/GithubRepositoryServiceTest.java
@@ -16,9 +16,9 @@ import org.mockito.Mockito;
 public class GithubRepositoryServiceTest {
     private TaskListener listenerMock;
     private GithubRepositoryService githubRepositoryService;
-    private final String TEST_REPOSITORY_URL_CLOUD = "https://github.com/user/fake-repo";
-    private final String TEST_REPOSITORY_URL_ENTERPRISE = "https://custom.githubserver.com/user/fake-repo";
-    private final String TEST_REPOSITORY_ENTERPRISE_IP = "https://10.0.0.97:8181/user/fake-repo";
+    private final String CLOUD_API_URI = "https://api.github.com";
+    private final String ENTERPRISE_API_URI = "https://custom.githubserver.com/api/v3";
+    private final String ENTERPRISE_API_URI_WITH_IP = "https://10.0.0.97:8181/api/v3";
     private final String TEST_GITHUB_TOKEN = "MSDFSGOIIEGWGWEGFAKEKEY";
     private final Integer TEST_REPOSITORY_PULL_NUMBER = 7;
     private final String TEST_REPOSITORY_NAME = "TEST_REPO";
@@ -45,8 +45,8 @@ public class GithubRepositoryServiceTest {
                 TEST_REPOSITORY_OWNER,
                 TEST_REPOSITORY_PULL_NUMBER,
                 TEST_REPOSITORY_BRANCH_NAME,
-                TEST_REPOSITORY_URL_CLOUD,
-                true);
+                true,
+                CLOUD_API_URI);
 
         assertEquals(
                 githubCloud.getUser().getToken(),
@@ -63,8 +63,8 @@ public class GithubRepositoryServiceTest {
                 TEST_REPOSITORY_OWNER,
                 TEST_REPOSITORY_PULL_NUMBER,
                 TEST_REPOSITORY_BRANCH_NAME,
-                TEST_REPOSITORY_URL_ENTERPRISE,
-                true);
+                true,
+                ENTERPRISE_API_URI);
 
         assertEquals(
                 githubEnterprise.getUser().getToken(),
@@ -81,8 +81,8 @@ public class GithubRepositoryServiceTest {
                 TEST_REPOSITORY_OWNER,
                 TEST_REPOSITORY_PULL_NUMBER,
                 TEST_REPOSITORY_BRANCH_NAME,
-                TEST_REPOSITORY_ENTERPRISE_IP,
-                true);
+                true,
+                ENTERPRISE_API_URI_WITH_IP);
 
         assertEquals(githubEnterpriseIp.getHost().getUrl(), "https://10.0.0.97:8181/");
     }
@@ -99,20 +99,7 @@ public class GithubRepositoryServiceTest {
                         TEST_REPOSITORY_OWNER,
                         TEST_REPOSITORY_PULL_NUMBER,
                         TEST_REPOSITORY_BRANCH_NAME,
-                        TEST_REPOSITORY_URL_CLOUD,
-                        true));
-    }
-
-    @Test
-    void extractGitHubHostTest() {
-        String githubCloudHost = githubRepositoryService.extractGitHubHost(TEST_REPOSITORY_URL_CLOUD);
-        String githubEnterPriseHost = githubRepositoryService.extractGitHubHost(TEST_REPOSITORY_URL_ENTERPRISE);
-        String githubEnterpriseIpHost = githubRepositoryService.extractGitHubHost(TEST_REPOSITORY_ENTERPRISE_IP);
-        String invalidGithubHost = githubRepositoryService.extractGitHubHost("invalid.url");
-
-        assertEquals(githubCloudHost, "https://github.com/");
-        assertEquals(githubEnterPriseHost, "https://custom.githubserver.com/");
-        assertEquals(githubEnterpriseIpHost, "https://10.0.0.97:8181/");
-        assertEquals(invalidGithubHost, "Invalid Github repository URL");
+                        true,
+                        CLOUD_API_URI));
     }
 }


### PR DESCRIPTION
- Added SARIF related Input parameters in the UI/config.jelly file.

- Mapped those UI input with the java properties.

- Added the validation logic for these properties.

- Added few more new methods in the SecurityScan Interface.

- On top of the SIGINT-1198-Blackduck, written generic and reusable code so that with the same code we can generate the sarif report for both multibranch pipeline and freestyle.