### PR TITLE
SIGINT-1530:  Support Polaris sarif parameters through freestyle, scripted, pipeline

### DIFF
--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/SecurityScan.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/SecurityScan.java
@@ -78,4 +78,15 @@ public interface SecurityScan {
     public String getBlackduck_reports_sarif_severities();
 
     public Boolean isReturn_status();
+
+    public Boolean isPolaris_reports_sarif_create();
+
+    public String getPolaris_reports_sarif_file_path();
+
+    public Boolean isPolaris_reports_sarif_groupSCAIssues();
+
+    public String getPolaris_reports_sarif_severities();
+
+    public String getPolaris_reports_sarif_issue_types();
+
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/SecurityScan.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/SecurityScan.java
@@ -88,5 +88,4 @@ public interface SecurityScan {
     public String getPolaris_reports_sarif_severities();
 
     public String getPolaris_reports_sarif_issue_types();
-
 }

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle.java
@@ -63,6 +63,11 @@ public class SecurityScanFreestyle extends Builder implements SecurityScan, Simp
     private String polaris_triage;
     private String polaris_branch_name;
     //    private String polaris_branch_parent_name;
+    private Boolean polaris_reports_sarif_create;
+    private String polaris_reports_sarif_file_path;
+    private String polaris_reports_sarif_issue_types;
+    private Boolean polaris_reports_sarif_groupSCAIssues;
+    private String polaris_reports_sarif_severities;
 
     private transient String bitbucket_token;
 
@@ -198,6 +203,26 @@ public class SecurityScanFreestyle extends Builder implements SecurityScan, Simp
         return polaris_branch_name;
     }
 
+    public Boolean isPolaris_reports_sarif_create() {
+        return polaris_reports_sarif_create;
+    }
+
+    public String getPolaris_reports_sarif_file_path() {
+        return polaris_reports_sarif_file_path;
+    }
+
+    public Boolean isPolaris_reports_sarif_groupSCAIssues() {
+        return polaris_reports_sarif_groupSCAIssues;
+    }
+
+    public String getPolaris_reports_sarif_severities() {
+        return polaris_reports_sarif_severities;
+    }
+
+    public String getPolaris_reports_sarif_issue_types() {
+        return polaris_reports_sarif_issue_types;
+    }
+
     public String getBitbucket_token() {
         return bitbucket_token;
     }
@@ -233,6 +258,7 @@ public class SecurityScanFreestyle extends Builder implements SecurityScan, Simp
     public Boolean isReturn_status() {
         return return_status;
     }
+
 
     @DataBoundSetter
     public void setProduct(String product) {
@@ -383,6 +409,31 @@ public class SecurityScanFreestyle extends Builder implements SecurityScan, Simp
     @DataBoundSetter
     public void setPolaris_branch_name(String polaris_branch_name) {
         this.polaris_branch_name = Util.fixEmptyAndTrim(polaris_branch_name);
+    }
+
+    @DataBoundSetter
+    public void setPolaris_reports_sarif_create(Boolean polaris_reports_sarif_create) {
+        this.polaris_reports_sarif_create = polaris_reports_sarif_create ? true : null;
+    }
+
+    @DataBoundSetter
+    public void setPolaris_reports_sarif_file_path(String polaris_reports_sarif_file_path) {
+        this.polaris_reports_sarif_file_path = Util.fixEmptyAndTrim(polaris_reports_sarif_file_path);
+    }
+
+    @DataBoundSetter
+    public void setPolaris_reports_sarif_groupSCAIssues(Boolean polaris_reports_sarif_groupSCAIssues) {
+        this.polaris_reports_sarif_groupSCAIssues = polaris_reports_sarif_groupSCAIssues ? true : null;
+    }
+
+    @DataBoundSetter
+    public void setPolaris_reports_sarif_severities(String polaris_reports_sarif_severities) {
+        this.polaris_reports_sarif_severities = Util.fixEmptyAndTrim(polaris_reports_sarif_severities);
+    }
+
+    @DataBoundSetter
+    public void setPolaris_reports_sarif_issue_types(String polaris_reports_sarif_issue_types) {
+        this.polaris_reports_sarif_issue_types = Util.fixEmptyAndTrim(polaris_reports_sarif_issue_types);
     }
 
     @DataBoundSetter

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle.java
@@ -259,7 +259,6 @@ public class SecurityScanFreestyle extends Builder implements SecurityScan, Simp
         return return_status;
     }
 
-
     @DataBoundSetter
     public void setProduct(String product) {
         this.product = product;

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactory.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactory.java
@@ -378,33 +378,33 @@ public class ScanParametersFactory {
                     securityScan.getBlackduck_reports_sarif_severities());
         }
 
-        if (scanStep.isPolaris_reports_sarif_create() != null) {
+        if (securityScan.isPolaris_reports_sarif_create() != null) {
             sarifParameters.put(
-                    ApplicationConstants.POLARIS_REPORTS_SARIF_CREATE_KEY, scanStep.isPolaris_reports_sarif_create());
+                    ApplicationConstants.POLARIS_REPORTS_SARIF_CREATE_KEY, securityScan.isPolaris_reports_sarif_create());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getPolaris_reports_sarif_file_path())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getPolaris_reports_sarif_file_path())) {
             sarifParameters.put(
                     ApplicationConstants.POLARIS_REPORTS_SARIF_FILE_PATH_KEY,
-                    scanStep.getPolaris_reports_sarif_file_path());
+                    securityScan.getPolaris_reports_sarif_file_path());
         }
 
-        if (scanStep.isPolaris_reports_sarif_groupSCAIssues() != null) {
+        if (securityScan.isPolaris_reports_sarif_groupSCAIssues() != null) {
             sarifParameters.put(
                     ApplicationConstants.POLARIS_REPORTS_SARIF_GROUPSCAISSUES_KEY,
-                    scanStep.isPolaris_reports_sarif_groupSCAIssues());
+                    securityScan.isPolaris_reports_sarif_groupSCAIssues());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getPolaris_reports_sarif_severities())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getPolaris_reports_sarif_severities())) {
             sarifParameters.put(
                     ApplicationConstants.POLARIS_REPORTS_SARIF_SEVERITIES_KEY,
-                    scanStep.getPolaris_reports_sarif_severities());
+                    securityScan.getPolaris_reports_sarif_severities());
         }
 
-        if (!Utility.isStringNullOrBlank(scanStep.getPolaris_reports_sarif_issue_types())) {
+        if (!Utility.isStringNullOrBlank(securityScan.getPolaris_reports_sarif_issue_types())) {
             sarifParameters.put(
                     ApplicationConstants.POLARIS_REPORTS_SARIF_ISSUE_TYPES_KEY,
-                    scanStep.getPolaris_reports_sarif_issue_types());
+                    securityScan.getPolaris_reports_sarif_issue_types());
         }
 
         return sarifParameters;

--- a/src/main/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactory.java
+++ b/src/main/java/io/jenkins/plugins/synopsys/security/scan/factory/ScanParametersFactory.java
@@ -380,7 +380,8 @@ public class ScanParametersFactory {
 
         if (securityScan.isPolaris_reports_sarif_create() != null) {
             sarifParameters.put(
-                    ApplicationConstants.POLARIS_REPORTS_SARIF_CREATE_KEY, securityScan.isPolaris_reports_sarif_create());
+                    ApplicationConstants.POLARIS_REPORTS_SARIF_CREATE_KEY,
+                    securityScan.isPolaris_reports_sarif_create());
         }
 
         if (!Utility.isStringNullOrBlank(securityScan.getPolaris_reports_sarif_file_path())) {

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/config.jelly
@@ -82,6 +82,23 @@
                 <f:textbox/>
             </f:entry>
         </f:section>
+        <f:section title="SARIF Report Options">
+            <f:entry field="polaris_reports_sarif_create" title="Generate SARIF Report for Polaris Issues (Optional)">
+                <f:checkbox/>
+            </f:entry>
+            <f:entry field="polaris_reports_sarif_groupSCAIssues" title="Group SCA Issues by Component (Optional)">
+                <f:checkbox/>
+            </f:entry>
+            <f:entry field="polaris_reports_sarif_file_path" title="Polaris SARIF Report File Path (Optional)">
+                <f:textbox/>
+            </f:entry>
+            <f:entry field="polaris_reports_sarif_issue_types" title="Polaris SARIF Report Issue Types (Optional)">
+                <f:textbox/>
+            </f:entry>
+            <f:entry field="polaris_reports_sarif_severities" title="Polaris SARIF Report Severities (Optional)">
+                <f:textbox/>
+            </f:entry>
+        </f:section>
     </div>
 
     <f:section title="Additional Options">

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_reports_sarif_create.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_reports_sarif_create.html
@@ -1,0 +1,3 @@
+<div>
+    SARIF report will be uploaded as a Jenkins Archive Artifact.
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_reports_sarif_file_path.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_reports_sarif_file_path.html
@@ -1,0 +1,3 @@
+<div>
+    File path (including file name) where SARIF report is created.
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_reports_sarif_groupSCAIssues.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_reports_sarif_groupSCAIssues.html
@@ -1,0 +1,3 @@
+<div>
+    Uncheck this to disable grouping by component and list SCA issues by vulnerability.
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_reports_sarif_severities.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-blackduck_reports_sarif_severities.html
@@ -1,0 +1,3 @@
+<div>
+    Comma separated list of issue severities to include in SARIF report. Supported values: <code>CRITICAL,HIGH,MEDIUM,LOW</code>
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_reports_sarif_create.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_reports_sarif_create.html
@@ -1,0 +1,3 @@
+<div>
+    SARIF report will be uploaded as a Jenkins Archive Artifact.
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_reports_sarif_file_path.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_reports_sarif_file_path.html
@@ -1,0 +1,3 @@
+<div>
+    File path (including file name) where SARIF report is created.
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_reports_sarif_groupSCAIssues.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_reports_sarif_groupSCAIssues.html
@@ -1,0 +1,3 @@
+<div>
+    Uncheck this to disable grouping by component and list SCA issues by vulnerability.
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_reports_sarif_issue_types.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_reports_sarif_issue_types.html
@@ -1,0 +1,3 @@
+<div>
+    Comma separated list of issues types to include in SARIF report. Supported values: <code>SAST</code>, <code>SCA</code>
+</div>

--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_reports_sarif_severities.html
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/freestyle/SecurityScanFreestyle/help-polaris_reports_sarif_severities.html
@@ -1,0 +1,3 @@
+<div>
+    Comma separated list of issue severities to include in SARIF report. Supported values: <code>CRITICAL,HIGH,MEDIUM,LOW</code>
+</div>


### PR DESCRIPTION
- Added SARIF related Input parameters for Polaris in the UI/config.jelly file.
- Mapped those UI input with the java properties.
- Added the validation logic for these properties.
- Added few more new methods in the SecurityScan Interface.
- On top of the SIGINT-1198, written generic and reusable code so that with the same code we can generate the sarif report for both multibranch pipeline and freestyle