### PR TITLE
Commented out return status from pipeline syntax for 1.2.z

### DIFF
--- a/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/synopsys/security/scan/extension/pipeline/SecurityScanStep/config.jelly
@@ -77,9 +77,9 @@
         <f:entry field="network_airgap" title="Network Airgap (Optional)">
             <f:checkbox/>
         </f:entry>
-        <f:entry field="return_status" title="Return Status Code (Optional)">
-            <f:checkbox/>
-        </f:entry>
+<!--        <f:entry field="return_status" title="Return Status Code (Optional)">-->
+<!--            <f:checkbox/>-->
+<!--        </f:entry>-->
     </f:section>
 
     <script type="text/javascript">


### PR DESCRIPTION
Commented out `return_status` field from pipeline syntax as it isn't planned for next release