### PR TITLE
SIGINT-1615: Fix security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
+      <!--<dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-core</artifactId>
         <version>5.8.5</version>
@@ -58,7 +58,7 @@
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-web</artifactId>
         <version>5.8.5</version>
-      </dependency>
+      </dependency>-->
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <revision>1.2.0</revision>
     <changelist>-SIGQA3</changelist>
+    <maven.compiler.release>17</maven.compiler.release>
     <jenkins.version>2.401.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
@@ -44,21 +45,21 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!--<dependency>
+      <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-core</artifactId>
-        <version>5.8.5</version>
+        <version>6.2.2</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-crypto</artifactId>
-        <version>5.8.5</version>
+        <version>6.2.2</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-web</artifactId>
-        <version>5.8.5</version>
-      </dependency>-->
+        <version>6.2.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <revision>1.2.0</revision>
-    <changelist>-SIGQA3</changelist>
+    <changelist>-SIGQA4</changelist>
     <maven.compiler.release>17</maven.compiler.release>
     <jenkins.version>2.401.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -53,11 +53,6 @@
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-crypto</artifactId>
-        <version>6.2.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-web</artifactId>
         <version>6.2.2</version>
       </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
         <artifactId>spring-security-crypto</artifactId>
         <version>6.2.2</version>
       </dependency>
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-web</artifactId>
+        <version>6.2.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
- Upgraded the spring-security-related libraries to the latest.
- Added `maven.compiler.release` to **JDK 17** as current spring security frameworks (6.x.x) requires **JDK 17**. Details can be found [here](https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions).