### PR TITLE
SIGINT-2119: synopsys-security-scan-plugin build leaving test files after running

### DIFF
--- a/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/ScannerArgumentServiceTest.java
+++ b/src/test/java/io/jenkins/plugins/synopsys/security/scan/service/ScannerArgumentServiceTest.java
@@ -568,7 +568,6 @@ public class ScannerArgumentServiceTest {
 
         List<String> commandLineArgs =
                 scannerArgumentService.getCommandLineArgs(installedDependencies, polarisParameters, workspace);
-        scannerArgumentService.getCommandLineArgs(installedDependencies, polarisParameters, workspace);
 
         if (getOSNameForTest().contains("win")) {
             assertEquals(


### PR DESCRIPTION
Issue: In one unit test case, json file was not cleaned up after executing the test.

Solution: Updated the unit test case. Now it is cleaning up the json file after test case execution.