### PR TITLE
Fix dependency issue for FlowNode class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,10 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
- `workflow-api` dependency added to fix the issue of the FlowNode class.